### PR TITLE
Add option to use relative paths in output

### DIFF
--- a/bin/scrape-versionista-and-upload
+++ b/bin/scrape-versionista-and-upload
@@ -63,6 +63,7 @@ function archiveAndUpload (email, password, callback) {
         '--format', 'json-stream',
         '--output', path.join(mainDirectory, `metadata-${timeString}.json`),
         '--errors', path.join(mainDirectory, `errors-${timeString}.log`),
+        '--relative-paths', path.join(outputDirectory),
         '--save-content',
         '--save-diffs'
       ],


### PR DESCRIPTION
Previously, the paths to diffs and content in the output CSV/JSON were absolute file paths. This makes it possible to make those paths relative (which makes these files much more sensible once they've been archived to a public S3/Google Cloud bucket).