### PR TITLE
Get “pages” from all page type categories

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -160,9 +160,19 @@ class Versionista {
   /**
    * Get an array of tracked pages for a given site.
    * @param {String} siteUrl URL of site page on Versionista
+   * @param {Boolean} [includeNonHtmlPages=true] Versionista sorts "pages" into
+   *        high level types: HTML, Images, Scripts. If false, only get HTML.
    * @returns {Promise<VersionistaPage[]>}
    */
-  getPages (siteUrl) {
+  getPages (siteUrl, includeNonHtmlPages = true) {
+    if (includeNonHtmlPages) {
+      return Promise.all([
+        this.getPages(siteUrl, false),
+        this.getPages(joinUrlPaths(siteUrl, 'catImages'), false),
+        this.getPages(joinUrlPaths(siteUrl, 'catScripts'), false)
+      ]).then(flatten);
+    }
+
     return this.request(siteUrl).then(window => {
       const pagingUrls = getPagingUrls(window);
 


### PR DESCRIPTION
Versionista has tabs that separate content into HTML, Images, and Scripts, which appears to happen based on the `Content-Type` header of the most recent version. It looks like all types used to be surfaced in the main list, but it's now only HTML (so we have some historic items from other, non-HTML tabs). It also seems that pages can move around between the tabs -- if an image suddenly returns a 404 or 500 error page with HTML in it, for example, it'll move from the Images tab to the HTML tab. If it later starts working again (not uncommon), then it'll move *back* to the Images tab.

This change also makes the default grabbing pages from all tabs, so we never lose versions because the moved between tabs.

<img width="591" alt="screen shot 2017-05-01 at 4 27 54 pm" src="https://cloud.githubusercontent.com/assets/74178/25599267/a9d9fd28-2e8f-11e7-8413-239e775373f0.png">
