### PR TITLE
Add script to import into web-monitoring-db

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,10 +1,12 @@
 # When using this on a server environment for regularly scheduled scrape jobs,
 # you'll probably want to make sure the following env vars are set (via whatever
 # means are reasonable depending how you are running things).
+# Note that you never *need* to set any of these; all configuration can also
+# be set as command line options for the various scripts.
 
 # Login information for Versionista
-export VERSIONISTA_EMAIL='xxx@gmail.com'
-export VERSIONISTA_PASSWORD='XYZ'
+export VERSIONISTA_EMAIL=xxx@gmail.com
+export VERSIONISTA_PASSWORD=XYZ
 
 # Name to use for Versionista account in output instead of e-mail address
 export VERSIONISTA_NAME=versionista1
@@ -16,3 +18,14 @@ export AWS_S3_BUCKET=XXX
 export GOOGLE_PROJECT_ID=XXX
 export GOOGLE_STORAGE_KEY_FILE=XXX.json
 export GOOGLE_BUCKET=XXX
+
+# Information about where to e-mail scrape metadata from/to
+export SEND_ARCHIVES_FROM=yyy@gmail.com
+export SEND_ARCHIVES_PASSWORD=XYZ
+export SEND_ARCHIVES_TO='abc@gmail.com, def@example.com'
+
+# Information about importing to a web-monitoring-db instance
+export WEB_MONITORING_EMAIL=zzz@gmail.com
+export WEB_MONITORING_PASSWORD=XYZ
+# NOTE: no need to specify this if at the default URL as below
+export WEB_MONITORING_URL=http://web-monitoring-db.herokuapp.com/

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -97,6 +97,10 @@ function importJsonFile (filePath, callback) {
 
       console.log(`Completed ${versionsTotal} versions.`);
     }),
+    // Unfortunately, pump only waits for the last stream's write end to finish,
+    // not for it to close or for its read end to end. This passthrough stream
+    // ensures the stream above finishes all its work before the callback :/
+    stream.PassThrough({objectMode: true}),
     callback
   );
 }
@@ -140,7 +144,10 @@ function mapStream (mapper) {
     objectMode: true,
     transform (data, encoding, callback) {
       try {
-        this.push(mapper(data));
+        const result = mapper(data);
+        if (result != null) {
+          this.push(result);
+        }
         callback();
       }
       catch (error) {

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -24,6 +24,9 @@ Options:
                    data to an alternate instance of the DB.
                    [default: https://web-monitoring-db.herokuapp.com/]
                    [env: WEB_MONITORING_URL]
+  --bucket BUCKET  Amazon S3 bucket that is hosting raw version data.
+                   [default: edgi-versionista-archive]
+                   [env: AWS_S3_BUCKET]
   --chunk SIZE     Send versions in chunks of this size. [default: 1000]
 `);
 
@@ -36,6 +39,7 @@ const chunkSize = args['--chunk'];
 const versionFilePaths = args['<paths>'];
 const email = args['--email'];
 const password = args['--password'];
+const bucket = args['--bucket'];
 const startDate = Date.now();
 
 function importableVersion (version) {
@@ -46,7 +50,7 @@ function importableVersion (version) {
       `${version.siteId}-${version.pageId}`,
       path.basename(version.filePath)
     ].join('/');
-    s3Url = `https://edgi-versionista-archive.s3.amazonaws.com/${s3Path}`;
+    s3Url = `https://${bucket}.s3.amazonaws.com/${s3Path}`;
   }
 
   return {

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const stream = require('stream');
+const fs = require('fs');
+const neodoc = require('neodoc');
+const parallel = require('parallel-transform');
+const pump = require('pump');
+const request = require('request');
+const split = require('split');
+
+const args = neodoc.run(`
+Sends the contents of an JSON-stream versions file generated scrape-versionista
+to an instance of web-monitoring-db.
+
+Usage: import-to-db [options] <path>
+
+Options:
+  -h, --help       Print this lovely help message.
+  --email EMAIL    E-Mail for web-monitoring-db [env: WEB_MONITORING_EMAIL]
+  --password PASS  PASSWORD for web-monitoring-db [env: WEB_MONITORING_PASSWORD]
+  --host HOST      Alternate host name for web-monitoring-db. Use this to send
+                   data to an alternate instance of the DB.
+                   [default: https://web-monitoring-db.herokuapp.com/]
+  --chunk SIZE     Send versions in chunks of this size. [default: 1000]
+`);
+
+if (!args['--host'].endsWith('/')) {
+  args['--host'] += '/';
+}
+
+const dbUrl = `${args['--host']}api/v0/imports`
+const chunkSize = args['--chunk'];
+const versionsDataPath = args['<path>'];
+const email = args['--email'];
+const password = args['--password'];
+const startDate = Date.now();
+
+function importableVersion (version) {
+  let s3Url = undefined;
+  if (version.filePath) {
+    let s3Path = [
+      version.account,
+      `${version.siteId}-${version.pageId}`,
+      path.basename(version.filePath)
+    ].join('/');
+    s3Url = `https://edgi-versionista-archive.s3.amazonaws.com/${s3Path}`;
+  }
+
+  return {
+    page_url: version.pageUrl,
+    page_title: version.pageTitle,
+    site_agency: version.agency,
+    site_name: version.siteName,
+    capture_time: version.date,
+    uri: s3Url,
+    version_hash: version.hash,
+    source_type: 'versionista',
+    source_metadata: {
+      account: version.account,
+      site_id: version.siteId,
+      page_id: version.pageId,
+      version_id: version.versionId,
+      url: version.url,
+      has_content: version.hasContent,
+      errorCode: version.is404Page ? '404' : version.errorCode,
+      diff_with_previous_url: version.diffWithPreviousUrl,
+      diff_with_first_url: version.diffWithFirstUrl,
+      diff_hash: version.diff && version.diff.hash,
+      diff_length: version.diff && version.diff.length
+    }
+  };
+}
+
+let exitCode = 0;
+let versionsImported = 0;
+let versionsTotal = 0;
+pump(
+  fs.createReadStream(versionsDataPath),
+  split(line => (line === '' ? null : JSON.parse(line))),
+  mapStream(importableVersion),
+  chunkedObjectStream(chunkSize),
+  parallel(5, importIntoDb),
+  mapStream(importResult => {
+    const errors = importResult.processing_errors;
+    versionsTotal += importResult.processed_versions;
+    versionsImported += importResult.processed_versions - errors.length;
+
+    if (errors.length) {
+      exitCode = 1;
+      errors.forEach(error => console.error(error));
+    }
+
+    console.log(`Completed ${versionsTotal} versions.`);
+  }),
+  error => {
+    if (error) {
+      exitCode = 1;
+      console.error(error);
+    }
+
+    console.error(`Completed in ${(Date.now() - startDate) / 1000} seconds.`);
+    console.error(`  ${versionsImported} of ${versionsTotal} imported.`)
+    process.exit(exitCode);
+  }
+);
+
+
+// HELPERS -----------------
+
+function mapStream (mapper) {
+  return stream.Transform({
+    objectMode: true,
+    transform (data, encoding, callback) {
+      try {
+        this.push(mapper(data));
+        callback();
+      }
+      catch (error) {
+        return callback(error);
+      }
+    }
+  });
+}
+
+function filterStream (predicate) {
+  return stream.Transform({
+    objectMode: true,
+    transform (data, encoding, callback) {
+      try {
+        if (predicate(data)) {
+          this.push(data);
+        }
+        callback();
+      }
+      catch (error) {
+        return callback(error);
+      }
+    }
+  });
+}
+
+function chunkedObjectStream (chunkSize = Infinity) {
+  if (chunkSize < 1 || typeof chunkSize !== 'number') {
+    chunkSize = 1;
+  }
+
+  return stream.Transform({
+    objectMode: true,
+    transform (data, encoding, callback) {
+      if (!this._chunkBuffer) {
+        this._chunkBuffer = [];
+      }
+      this._chunkBuffer.push(data);
+      if (this._chunkBuffer.length === chunkSize) {
+        this.push(this._chunkBuffer);
+        this._chunkBuffer = [];
+      }
+      callback();
+    },
+    flush (callback) {
+      if (this._chunkBuffer.length) {
+        this.push(this._chunkBuffer);
+      }
+      this._chunkBuffer = null;
+      callback();
+    }
+  });
+}
+
+function importIntoDb (versions, callback) {
+  request({
+    method: 'POST',
+    url: dbUrl,
+    auth: {username: email, password},
+    headers: {'Content-Type': 'application/x-json-stream'},
+    body: versions.map(v => JSON.stringify(v)).join('\n')
+  }, (error, response, rawBody) => {
+    if (error) {
+      return callback(error)
+    }
+
+    const body = JSON.parse(rawBody);
+
+    if (body.errors) {
+      return callback(body.errors[0]);
+    }
+
+    const importId = body.data.id;
+    const poll = (callback) => {
+      setTimeout(() => {
+        request({
+          url: `${dbUrl}/${importId}`,
+          auth: {username: email, password},
+          json: true
+        }, (error, response, body) => {
+          if (error) {
+            return callback(error);
+          }
+          else if (body.data.status !== 'complete') {
+            return poll(callback);
+          }
+
+          body.data.processed_versions = versions.length;
+          callback(null, body.data);
+        });
+      }, 1000);
+    };
+
+    poll(callback);
+  });
+}

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -23,6 +23,7 @@ Options:
   --host HOST      Alternate host name for web-monitoring-db. Use this to send
                    data to an alternate instance of the DB.
                    [default: https://web-monitoring-db.herokuapp.com/]
+                   [env: WEB_MONITORING_URL]
   --chunk SIZE     Send versions in chunks of this size. [default: 1000]
 `);
 

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -186,7 +186,7 @@ function chunkedObjectStream (chunkSize = Infinity) {
       callback();
     },
     flush (callback) {
-      if (this._chunkBuffer.length) {
+      if (this._chunkBuffer && this._chunkBuffer.length) {
         this.push(this._chunkBuffer);
       }
       this._chunkBuffer = null;

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
-const fs = require('fs');
 const neodoc = require('neodoc');
 const parallel = require('parallel-transform');
 const pump = require('pump');
@@ -14,7 +14,7 @@ const args = neodoc.run(`
 Sends the contents of an JSON-stream versions file generated scrape-versionista
 to an instance of web-monitoring-db.
 
-Usage: import-to-db [options] <path>
+Usage: import-to-db [options] <paths>...
 
 Options:
   -h, --help       Print this lovely help message.
@@ -32,7 +32,7 @@ if (!args['--host'].endsWith('/')) {
 
 const dbUrl = `${args['--host']}api/v0/imports`
 const chunkSize = args['--chunk'];
-const versionsDataPath = args['<path>'];
+const versionFilePaths = args['<paths>'];
 const email = args['--email'];
 const password = args['--password'];
 const startDate = Date.now();
@@ -76,35 +76,61 @@ function importableVersion (version) {
 let exitCode = 0;
 let versionsImported = 0;
 let versionsTotal = 0;
-pump(
-  fs.createReadStream(versionsDataPath),
-  split(line => (line === '' ? null : JSON.parse(line))),
-  mapStream(importableVersion),
-  chunkedObjectStream(chunkSize),
-  parallel(5, importIntoDb),
-  mapStream(importResult => {
-    const errors = importResult.processing_errors;
-    versionsTotal += importResult.processed_versions;
-    versionsImported += importResult.processed_versions - errors.length;
+let filesTotal = 0;
 
-    if (errors.length) {
-      exitCode = 1;
-      errors.forEach(error => console.error(error));
-    }
+function importJsonFile (filePath, callback) {
+  pump(
+    fs.createReadStream(filePath),
+    split(line => (line === '' ? null : JSON.parse(line))),
+    mapStream(importableVersion),
+    chunkedObjectStream(chunkSize),
+    parallel(5, importIntoDb),
+    mapStream(importResult => {
+      const errors = importResult.processing_errors;
+      versionsTotal += importResult.processed_versions;
+      versionsImported += importResult.processed_versions - errors.length;
 
-    console.log(`Completed ${versionsTotal} versions.`);
-  }),
-  error => {
-    if (error) {
-      exitCode = 1;
-      console.error(error);
-    }
+      if (errors.length) {
+        exitCode = 1;
+        errors.forEach(error => console.error(error));
+      }
 
-    console.error(`Completed in ${(Date.now() - startDate) / 1000} seconds.`);
-    console.error(`  ${versionsImported} of ${versionsTotal} imported.`)
-    process.exit(exitCode);
+      console.log(`Completed ${versionsTotal} versions.`);
+    }),
+    callback
+  );
+}
+
+function complete (error) {
+  if (error) {
+    exitCode = 1;
+    console.error(error);
   }
-);
+
+  console.error(`Completed in ${(Date.now() - startDate) / 1000} seconds.`);
+  console.error(`  ${versionsImported} of ${versionsTotal} imported from ${filesTotal} files.`)
+  process.exit(exitCode);
+}
+
+function processNextFile () {
+  const filePath = versionFilePaths.shift();
+  if (filePath) {
+    console.error(`Loading "${filePath}"`);
+    importJsonFile(filePath, error => {
+      filesTotal++;
+      if (error) {
+        return complete(error);
+      }
+      processNextFile();
+    });
+  }
+  else {
+    complete();
+  }
+}
+
+// GO!!!!
+processNextFile();
 
 
 // HELPERS -----------------

--- a/bin/scrape-versionista-and-upload
+++ b/bin/scrape-versionista-and-upload
@@ -147,6 +147,11 @@ function upload (account, callback) {
 }
 
 function importToDb (account, callback) {
+  if (!args['--db-email'] || !args['--db-password']) {
+    console.error('Nothing imported to web-monitoring-db (not configured)');
+    callback();
+  }
+
   const metadataPath = path.join(
     outputDirectory,
     account,

--- a/bin/scrape-versionista-and-upload
+++ b/bin/scrape-versionista-and-upload
@@ -23,6 +23,9 @@ Options:
   --google-key PATH     Google Cloud key file [env: GOOGLE_STORAGE_KEY_FILE]
   --google-bucket NAME  Google Could bucket to upload to [env: GOOGLE_BUCKET]
   --throughput NUM      Number of simultaneous uploads to allow
+  --db-email STRING     Login e-mail for web-monitoring-db [env: WEB_MONITORING_EMAIL]
+  --db-password STRING  Password for web-monitoring-db [env: WEB_MONITORING_PASSWORD]
+  --db-url STRING       URL for web-monitoring-db instance [env: WEB_MONITORING_URL]
 `);
 
 const scriptsPath = __dirname;
@@ -129,13 +132,42 @@ function upload (account, callback) {
   s3.on('close', code => {
     if (code == 0) {
       console.error('Successfully uploaded to S3');
+      importToDb(account, complete);
     }
-    complete(code ? 'Failed to upload to S3.' : null);
+    else {
+      complete('Failed to upload to S3');
+    }
   });
   google.on('close', code => {
     if (code == 0) {
       console.error('Successfully uploaded to Google Cloud');
     }
     complete(code ? 'Failed to upload to Google Cloud.' : null);
+  });
+}
+
+function importToDb (account, callback) {
+  const metadataPath = path.join(
+    outputDirectory,
+    account,
+    `metadata-${timeString}.json`);
+
+  const importProcess = spawn(
+    path.join(scriptsPath, 'import-to-db'),
+    [
+      '--email', args['--db-email'],
+      '--password', args['--db-password'],
+      '--host', args['--db-url'],
+      metadataPath
+    ],
+    {
+      stdio: 'inherit'
+    });
+
+  importProcess.on('close', code => {
+    if (code == 0) {
+      console.error(`Successfully imported into ${args['--db-url']}`);
+    }
+    callback(code ? 'Failed to import to DB.' : null);
   });
 }


### PR DESCRIPTION
~**DO NOT MERGE**~

This goes along with https://github.com/edgi-govdata-archiving/web-monitoring-db/issues/19 and shouldn’t be merged quite yet as it will need to track any changes that happen to the import API there.

Fixes #11.

Needs:

- [x] Upstream `web-monitoring-db` to get squared away
- [x] Update sample env file
- [x] Integrate with `scrape-versionista-and-upload` script
