### PR TITLE
Add option --group-by-site (fixes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# versoinista-edgi-node
+# web-monitoring-versionista-scraper
 
 This is a version of [versionista-outputter](https://github.com/edgi-govdata-archiving/versionista-outputter) that has been rewritten in Node.js and JSDom.
 
@@ -10,13 +10,19 @@ Why? Speed is important here. Scraping Versionista can take a *long* time. We do
 You’ll need Node.js. Then you should be able to globally install this with:
 
 ```sh
-$ npm install -g https://github.com/Mr0grog/versionista-edgi-node.git
+$ npm install -g https://github.com/edgi-govdata-archiving/web-monitoring-versionista-scraper.git
 ```
 
 Then run it like so:
 
 ```sh
 $ scrape-versionista --email EMAIL --password PASSWORD --after '2017-03-22' --format csv --output './scrape/versions.csv'
+```
+
+You can also split output into multiple files (by site) with the `--group-by-site` option:
+
+```sh
+$ scrape-versionista --email EMAIL --password PASSWORD --after '2017-03-22' --format csv --output './scrape/versions.csv' --group-by-site
 ```
 
 Alternatively, you can clone this repo, then:
@@ -58,6 +64,8 @@ $ scrape-versionista --help
 - `--save-content` If set, the raw HTML of each captured version will also be saved. Files are written to the working directory or, if `--output` is specified, the same directory as the output file.
 
 - `--save-diffs` If set, the HTML of diffs between a version and its previous version will also be saved.Files are written to the working directory or, if `--output` is specified, the same directory as the output file.
+
+- `--group-by-site` If set, a separate output file will be generated for each site. Files are placed in the same directory as `--output`, so the actual filename specified in `--output` will never be created.
 
 
 ## Examples

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -45,6 +45,10 @@ Options:
   --save-diffs           Save HTML of diffs between versions. Outputs in the
                          same fashion as --save-content.
   --relative-paths PATH  Make file paths in output data relative to this path.
+  --group-by-site        Instead of one output file, create one file per site.
+                         Like other output, the files will be created in the
+                         same directory as --output. Note this means the actual
+                         filename specified in --output will never be written.
 `);
 
 args['--email'] = args['--email'] || process.env.VERSIONISTA_EMAIL;
@@ -344,21 +348,58 @@ let versions = pages
     return versions;
   });
 
-versions
-  .then(() => sites)
-  .then(data => formatter(data, {
-    account: args['--account-name'],
-    includeDiffs: args['--save-diffs'],
-    includeContent: args['--save-content']
-  }))
-  .then(formatted => {
-    if (args['--output']) {
-      return writeFile(path.basename(args['--output']), formatted);
-    }
-    else {
-      process.stdout.write(formatted);
-    }
-  })
+
+let files;
+const completeData = versions.then(() => sites);
+
+if (args['--output'] && args['--group-by-site']) {
+  files = completeData
+    // filter out sites without actual updates
+    .then(sites => sites.filter(
+      site => site.pages && site.pages.some(
+        page => page.versions && page.versions.length
+      )
+    ))
+    // format each individually
+    .then(sites => {
+      return sites.map(site => {
+        return {
+          name: site.name,
+          content: formatter([site], {
+            account: args['--account-name'],
+            includeDiffs: args['--save-diffs'],
+            includeContent: args['--save-content']
+          })
+        };
+      });
+    })
+    .then(formattedSites => {
+      const dateString = new Date(startTime).toISOString();
+      const files = formattedSites.map(site => {
+        const filename = `${site.name}_${dateString}.csv`.replace(/[:/]/g, '_');
+        return writeFile(filename, site.content);
+      });
+      return Promise.all(files);
+    });
+}
+else {
+  files = completeData
+    .then(data => formatter(data, {
+      account: args['--account-name'],
+      includeDiffs: args['--save-diffs'],
+      includeContent: args['--save-content']
+    }))
+    .then(formatted => {
+      if (args['--output']) {
+        return writeFile(path.basename(args['--output']), formatted);
+      }
+      else {
+        process.stdout.write(formatted);
+      }
+    });
+}
+
+files
   .catch(error => {
     logError(error);
   })


### PR DESCRIPTION
As you might guess, this causes the scraper to output a separate file for each site. This isn't the most beautiful code, but is a quick fix to be able to use this script for updated output for the tracking team, who is running into issues with the older script today.

Also fixes an incorrect title and URL in README