### PR TITLE
Add --latest-version-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ $ scrape-versionista --help
 
 - `--save-content` If set, the raw HTML of each captured version will also be saved. Files are written to the working directory or, if `--output` is specified, the same directory as the output file.
 
-- `--save-diffs` If set, the HTML of diffs between a version and its previous version will also be saved.Files are written to the working directory or, if `--output` is specified, the same directory as the output file.
+- `--save-diffs` If set, the HTML of diffs between a version and its previous version will also be saved. Files are written to the working directory or, if `--output` is specified, the same directory as the output file.
+
+- `--latest-version-only` If set, only the latest version (of the versions matching --after/--before times) for each page is captured.
 
 - `--group-by-site` If set, a separate output file will be generated for each site. Files are placed in the same directory as `--output`, so the actual filename specified in `--output` will never be created.
 

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -49,6 +49,8 @@ Options:
                          Like other output, the files will be created in the
                          same directory as --output. Note this means the actual
                          filename specified in --output will never be written.
+  --latest-version-only  Only include the latest version for each page (within
+                         the --after/--before date range).
 `);
 
 args['--email'] = args['--email'] || process.env.VERSIONISTA_EMAIL;
@@ -329,6 +331,12 @@ let versions = pages
     const versionsForPages = pages.map(page => {
       const versions = scraper.getVersions(page.versionistaUrl)
         .then(versions => versions.filter(isInRequestedDateRange))
+        .then(versions => {
+          if (args['--latest-version-only']) {
+            return versions.slice(-1);
+          }
+          return versions;
+        })
         .then(versions => {
           page.versions = versions;
           return versions;

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -36,8 +36,8 @@ module.exports = function formatCsv (sites, options = {}) {
 
   // TODO: this would be better as a flatmap
   sites.forEach(site => {
-    site.pages.forEach(page => {
-      page.versions.forEach(version => {
+    site.pages && site.pages.forEach(page => {
+      page.versions && page.versions.forEach(version => {
         rows.push(rowForVersion(site, page, version, options));
       });
     });

--- a/lib/formatters/json-stream.js
+++ b/lib/formatters/json-stream.js
@@ -12,8 +12,8 @@ module.exports = function formatJsonStream (sites, options = {}) {
 
   // TODO: this would be better as a flatmap
   sites.forEach(site => {
-    site.pages.forEach(page => {
-      page.versions.forEach(version => {
+    site.pages && site.pages.forEach(page => {
+      page.versions && page.versions.forEach(version => {
         const formatted = Object.assign({
           account: options.account,
           siteName: site.name,


### PR DESCRIPTION
This option restricts output to only the latest version for each page (the version still has to be within the date range filters specified by --before and --after). This gets output more like what the EDGI Tracking Team currently uses from the old Ruby script.