### PR TITLE
Add script to scrape metadata only and email it

### DIFF
--- a/bin/scrape-versionista-and-email
+++ b/bin/scrape-versionista-and-email
@@ -111,11 +111,14 @@ function sendResults (result) {
       to: args['--receiver-email']
     };
     const subjectDetails = `${versionista.name} @ ${friendlyDate}`
-    const signature = [
-      '\n\n- Your friendly scraperbot\n\n',
-      '\n\n- Your friendly scraperbot\n\n',
-      '\n\n- Mr. Scrapes\n\n'
-    ][Math.floor(Math.random() * 3)]
+    let signature = [
+      '- Your friendly scraperbot',
+      '- Your friendly scraperbot',
+      '- Mr. Scrapes',
+      '- Scrape-y McScrapesalot',
+      '- Sir Scraperbot'
+    ][Math.floor(Math.random() * 5)];
+    signature = `\n\n${signature}\n\n`;
 
     if (result instanceof Error) {
       message.subject = `Error scraping ${subjectDetails}`;

--- a/bin/scrape-versionista-and-email
+++ b/bin/scrape-versionista-and-email
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const spawn = require('child_process').spawn;
+const fs = require('fs-promise');
+const neodoc = require('neodoc');
+const nodemailer = require('nodemailer');
+
+const args = neodoc.run(`
+Usage: scrape-versionista-and-email [options]
+
+Options:
+  -h, --help              Print this lovely help message.
+  --after HOURS           Only include versions from N hours ago. [default: 72]
+  --output DIRECTORY      Write output to this directory.
+  --email STRING          Versionista account e-mail address [env: VERSIONISTA_EMAIL]
+  --password STRING       Versionista account password [env: VERSIONISTA_PASSWORD]
+  --account-name NAME     Name to use for Versionista account in output. [env: VERSIONISTA_NAME]
+  --sender-email STRING   E-mail address to send from. [env: SEND_ARCHIVES_FROM]
+  --sender-password PASS  Password for e-mail account to send from. [env: SEND_ARCHIVES_PASSWORD]
+  --receiver-email STRING E-mail address to send results to [env: SEND_ARCHIVES_TO]
+`);
+
+const scriptsPath = __dirname;
+const outputDirectory = path.resolve(args['--output']);
+
+const versionista = {
+  email: args['--email'],
+  password: args['--password'],
+  name: args['--account-name'] || email.match(/^(.+)@/)[1]
+};
+
+const senderEmailName = 'EDGI Versionista Scraper'
+const scrapeTime = new Date();
+// Use ISO Zulu time without seconds in our time strings
+const timeString = scrapeTime.toISOString().slice(0, 16) + 'Z';
+
+scrapeAccount()
+  .then(result => {
+    return compressPath(result.path).then(compressed => ({
+      text: result.text,
+      path: compressed
+    }));
+  })
+  .catch(error => error)
+  .then(sendResults)
+  .catch(error => console.error(error))
+  .then(() => run(`rm`, ['-rf', path.join(outputDirectory, '*')], {shell: true}));
+
+
+function scrapeAccount() {
+  const safeScrapeTime = timeString.replace(/:/g, '-');
+  const subdirectoryName = `${versionista.name}-${safeScrapeTime}`;
+  const directory = path.join(outputDirectory, subdirectoryName);
+  const errorFile = path.join(directory, `errors.log`);
+
+  return fs.ensureDir(directory)
+    .then(() => run(
+      path.join(scriptsPath, 'scrape-versionista'),
+      [
+        '--email', versionista.email,
+        '--password', versionista.password,
+        '--account-name', versionista.name,
+        '--after', args['--after'],
+        '--format', 'csv',
+        '--output', path.join(directory, `whatever.csv`),
+        '--errors', errorFile,
+        '--group-by-site',
+        '--latest-version-only'
+      ]
+    ))
+    .then(process => {
+      if (process.code === 0) {
+        return {
+          text: process.allIo,
+          path: directory
+        };
+      }
+
+      return fs.readFile(errorFile, 'utf8')
+        .then(errorText => {
+          const error = new Error(`Failed to scrape account ${email}`);
+          error.rawText = errorText;
+          throw error;
+        });
+    });
+}
+
+function compressPath (targetPath) {
+  const cwd = path.dirname(targetPath);
+  const inFile = path.basename(targetPath);
+  const outFile = `${inFile}.tar.gz`;
+
+  return run('tar', ['-czf', outFile, inFile], {cwd})
+    .then(process => {
+      if (process.code !== 0) {
+        throw new Error(`Failed to compress ${targetPath}: ${process.allIo}`);
+      }
+      return path.join(cwd, outFile);
+    });
+}
+
+function sendResults (result) {
+  return new Promise((resolve, reject) => {
+    const friendlyDate = timeString.replace('T', ' ').replace('Z', ' (GMT)');
+    const friendlyTime = friendlyDate.slice(11);
+
+    const message = {
+      from: `"${senderEmailName}" <${args['--sender-email']}>`,
+      to: args['--receiver-email']
+    };
+    const subjectDetails = `${versionista.name} @ ${friendlyDate}`
+    const signature = [
+      '\n\n- Your friendly scraperbot\n\n',
+      '\n\n- Your friendly scraperbot\n\n',
+      '\n\n- Mr. Scrapes\n\n'
+    ][Math.floor(Math.random() * 3)]
+
+    if (result instanceof Error) {
+      message.subject = `Error scraping ${subjectDetails}`;
+
+      const greeting = [
+        'Uhoh,',
+        'Troubles:',
+        'Problems :(',
+        '💩!'
+      ][Math.floor(Math.random() * 4)];
+
+      message.text = `${greeting}\n\nThere was an error scraping the last ${args['--after']} hours of versions out of ${versionista.name} at ${friendlyTime}:\n\n${result.rawText || result.message}\n${signature}`;
+    }
+    else {
+      message.subject = `Scraped ${subjectDetails}`;
+
+      const greeting = [
+        'Hi!',
+        'Howdy!',
+        'Good Morning!',
+        'Mornin’!',
+        'Hey,',
+        'Hot off the server!',
+        'Headed your way!'
+      ][Math.floor(Math.random() * 7)];
+
+      message.text = `${greeting}\n\nI scraped the last ${args['--after']} hours of versions out of ${versionista.name} at ${friendlyTime}.\n\n${result.text}${signature}`;
+      message.attachments = [{path: result.path}];
+    }
+
+    const transporter = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        user: args['--sender-email'],
+        pass: args['--sender-password']
+      }
+    });
+
+    transporter.sendMail(message, (error, result) => {
+      if (error) reject(error);
+      else resolve(result);
+    });
+  });
+}
+
+function run (command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    let allIo = '';
+    let stdout = '';
+    let stderr = '';
+
+    const child = spawn(command, args, Object.assign(options, {
+      stdio: 'pipe'
+    }))
+      .on('error', reject)
+      .on('close', code => {
+        resolve({
+          code,
+          allIo,
+          stdout,
+          stderr
+        });
+      });
+
+    child.stdout.on('data', data => {
+      allIo += data;
+      stdout += data;
+      process.stdout.write(data);
+    });
+
+    child.stderr.on('data', data => {
+      allIo += data;
+      stderr += data;
+      process.stderr.write(data);
+    });
+  });
+}

--- a/bin/scrape-versionista-and-email
+++ b/bin/scrape-versionista-and-email
@@ -67,7 +67,8 @@ function scrapeAccount() {
         '--output', path.join(directory, `whatever.csv`),
         '--errors', errorFile,
         '--group-by-site',
-        '--latest-version-only'
+        '--latest-version-only',
+        '--skip-error-versions'
       ]
     ))
     .then(process => {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "mime-types": "^2.1.15",
     "mkdirp": "^0.5.1",
     "neodoc": "^1.4.0",
+    "nodemailer": "^4.0.1",
     "parallel-transform": "^1.1.0",
     "pump": "^1.0.2",
     "request": "^2.81.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -872,6 +872,10 @@ node-uuid@~1.4.7:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.8.tgz#b040eb0923968afabf8d32fb1f17f1167fdab907"
 
+nodemailer@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-4.0.1.tgz#b95864b07facee8287e8232effd6f1d56ec75ab2"
+
 "nwmatcher@>= 1.3.9 < 2.0.0":
   version "1.3.9"
   resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.3.9.tgz#8bab486ff7fa3dfd086656bbe8b17116d3692d2a"


### PR DESCRIPTION
This will be used to do scheduled deliveries to support the Tracking Team's current workflow. Supports a few new env vars:

- `SEND_ARCHIVES_FROM` a **GMail** address to send e-mails with archived data
- `SEND_ARCHIVES_PASSWORD` password for above GMail account
- `SEND_ARCHIVES_TO` comma-delimited list of e-mail addresses to send results to