### PR TITLE
Import to multiple web-monitoring-db instances

### DIFF
--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -4,6 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
+const url = require('url');
 const neodoc = require('neodoc');
 const parallel = require('parallel-transform');
 const pump = require('pump');
@@ -30,15 +31,13 @@ Options:
   --chunk SIZE     Send versions in chunks of this size. [default: 1000]
 `);
 
-if (!args['--host'].endsWith('/')) {
-  args['--host'] += '/';
-}
-
-const dbUrl = `${args['--host']}api/v0/imports`
+const dbUrl = composeUrl(
+  args['--host'],
+  args['--email'],
+  args['--password'],
+  'api/v0/imports');
 const chunkSize = args['--chunk'];
 const versionFilePaths = args['<paths>'];
-const email = args['--email'];
-const password = args['--password'];
 const bucket = args['--bucket'];
 const startDate = Date.now();
 
@@ -207,11 +206,25 @@ function chunkedObjectStream (chunkSize = Infinity) {
   });
 }
 
+function composeUrl (sourceUrl, user, password, tail = '') {
+  const parsedUrl = url.parse(sourceUrl);
+
+  if (!parsedUrl.auth) {
+    parsedUrl.auth = `${user}:${password}`;
+  }
+
+  if (!parsedUrl.pathname.endsWith('/')) {
+    parsedUrl.pathname += '/';
+  }
+  parsedUrl.pathname += tail;
+
+  return url.format(parsedUrl);
+}
+
 function importIntoDb (versions, callback) {
   request({
     method: 'POST',
     url: dbUrl,
-    auth: {username: email, password},
     headers: {'Content-Type': 'application/x-json-stream'},
     body: versions.map(v => JSON.stringify(v)).join('\n')
   }, (error, response, rawBody) => {
@@ -230,7 +243,6 @@ function importIntoDb (versions, callback) {
       setTimeout(() => {
         request({
           url: `${dbUrl}/${importId}`,
-          auth: {username: email, password},
           json: true
         }, (error, response, body) => {
           if (error) {

--- a/bin/scrape-versionista-and-upload
+++ b/bin/scrape-versionista-and-upload
@@ -36,6 +36,11 @@ const scrapeTime = new Date();
 const timeString = scrapeTime.toISOString().slice(0, 16) + 'Z';
 const throughput = args['--throughput'] ? (args['--throughput'] / 2) : 0;
 
+const dbUrls = (args['--db-url'] || '')
+  .split(',')
+  .map(dbUrl => dbUrl.trim())
+  .filter(dbUrl => !!dbUrl);
+
 archiveAndUpload(args['--email'], args['--password'], error => {
   if (error) {
     console.error(error);
@@ -132,7 +137,7 @@ function upload (account, callback) {
   s3.on('close', code => {
     if (code == 0) {
       console.error('Successfully uploaded to S3');
-      importToDb(account, complete);
+      importToDbs(account, complete);
     }
     else {
       complete('Failed to upload to S3');
@@ -146,12 +151,26 @@ function upload (account, callback) {
   });
 }
 
-function importToDb (account, callback) {
-  if (!args['--db-email'] || !args['--db-password']) {
+function importToDbs (account, callback) {
+  let remaining = dbUrls.length;
+
+  if (remaining === 0) {
     console.error('Nothing imported to web-monitoring-db (not configured)');
-    callback();
+    return callback();
   }
 
+  for (let dbUrl of dbUrls) {
+    importToDb(dbUrl, account, error => {
+      remaining--;
+      if (remaining === 0 || error) {
+        remaining = 0;
+        callback(error);
+      }
+    });
+  }
+}
+
+function importToDb (dbUrl, account, callback) {
   const metadataPath = path.join(
     outputDirectory,
     account,
@@ -162,7 +181,7 @@ function importToDb (account, callback) {
     [
       '--email', args['--db-email'],
       '--password', args['--db-password'],
-      '--host', args['--db-url'],
+      '--host', dbUrl,
       metadataPath
     ],
     {
@@ -171,8 +190,8 @@ function importToDb (account, callback) {
 
   importProcess.on('close', code => {
     if (code == 0) {
-      console.error(`Successfully imported into ${args['--db-url']}`);
+      console.error(`Successfully imported into ${dbUrl}`);
     }
-    callback(code ? 'Failed to import to DB.' : null);
+    callback(code ? `Failed to import to DB ${dbUrl}.` : null);
   });
 }

--- a/bin/scrape-versionista-and-upload
+++ b/bin/scrape-versionista-and-upload
@@ -189,9 +189,14 @@ function importToDb (dbUrl, account, callback) {
     });
 
   importProcess.on('close', code => {
+    const loggableUrl = urlWithoutAuth(dbUrl);
     if (code == 0) {
-      console.error(`Successfully imported into ${dbUrl}`);
+      console.error(`Successfully imported into ${loggableUrl}`);
     }
-    callback(code ? `Failed to import to DB ${dbUrl}.` : null);
+    callback(code ? `Failed to import to DB ${loggableUrl}.` : null);
   });
+}
+
+function urlWithoutAuth (url) {
+  return url.replace(/^(\w+:\/\/)([^\/]+@)/, '$1');
 }


### PR DESCRIPTION
The `scrape-versionista-and-upload` script can now import to multiple web-monitoring-db instances by specifying a comma-separated list of DB URLs.

This will let us keep the staging server live-updated alongside the production server.