### PR TITLE
Fix broken e-mail signature line

### DIFF
--- a/bin/scrape-versionista-and-email
+++ b/bin/scrape-versionista-and-email
@@ -113,30 +113,30 @@ function sendResults (result) {
       to: args['--receiver-email']
     };
     const subjectDetails = `${versionista.name} @ ${friendlyDate}`
-    let signature = [
+    let signature = randomItem([
       '- Your friendly scraperbot',
       '- Your friendly scraperbot',
       '- Scrape-y McScrapesalot',
       '- Your faithful Scraperbot'
-    ][Math.floor(Math.random() * 5)];
+    ]);
     signature = `\n\n${signature}\n\n`;
 
     if (result instanceof Error) {
       message.subject = `Error scraping ${subjectDetails}`;
 
-      const greeting = [
+      const greeting = randomItem([
         'Uhoh,',
         'Troubles:',
         'Problems :(',
         '💩!'
-      ][Math.floor(Math.random() * 4)];
+      ]);
 
       message.text = `${greeting}\n\nThere was an error scraping the last ${args['--after']} hours of versions out of ${versionista.name} at ${friendlyTime}:\n\n${result.rawText || result.message}\n${signature}`;
     }
     else {
       message.subject = `Scraped ${subjectDetails}`;
 
-      const greeting = [
+      const greeting = randomItem([
         'Hi!',
         'Howdy!',
         'Good Morning!',
@@ -144,7 +144,7 @@ function sendResults (result) {
         'Hey,',
         'Hot off the server!',
         'Headed your way!'
-      ][Math.floor(Math.random() * 7)];
+      ]);
 
       message.text = `${greeting}\n\nI scraped the last ${args['--after']} hours of versions out of ${versionista.name} at ${friendlyTime}.\n\n${result.text}${signature}`;
       message.attachments = [{path: result.path}];
@@ -196,4 +196,8 @@ function run (command, args, options = {}) {
       process.stderr.write(data);
     });
   });
+}
+
+function randomItem (items) {
+  return items[Math.floor(Math.random() * items.length)]
 }


### PR DESCRIPTION
The changes I made in 706f3b4 neglected to address the changing size of the set of randomly chosen signatures. Hardcoding that size was dumb and I clearly paid for it when I tried to make a change. This fixes the error and also refactors so it won’t happen again.