### PR TITLE
Add configurable timing/rate limiting

### DIFF
--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -58,7 +58,7 @@ Options:
   --parallel NUMBER      Number of parallel connections to Versionista allowed.
   --pause-every NUMBER   Pause briefly after this many requests to Versionista.
   --pause-time MS        Milliseconds to pause for (see --pause-every)
-  --rate NUMBER          Maximum number of requests per minute (unimplemented!)
+  --rate NUMBER          Maximum number of requests per minute
 `);
 
 args['--email'] = args['--email'] || process.env.VERSIONISTA_EMAIL;

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -55,6 +55,10 @@ Options:
                          (e.g. 403, 500, etc. response codes) in primary output.
                          Error versions will be in a separate file alongside
                          primary output: error-versions.csv|json
+  --parallel NUMBER      Number of parallel connections to Versionista allowed.
+  --pause-every NUMBER   Pause briefly after this many requests to Versionista.
+  --pause-time MS        Milliseconds to pause for (see --pause-every)
+  --rate NUMBER          Maximum number of requests per minute (unimplemented!)
 `);
 
 args['--email'] = args['--email'] || process.env.VERSIONISTA_EMAIL;
@@ -166,9 +170,20 @@ function minimum (items, getValue = Number) {
   return smallestItem;
 }
 
+const clientOptions = {
+  maxSockets: args['--parallel'] && parseInt(args['--parallel'], 10),
+  sleepEvery: args['--pause-every'] && parseInt(args['--pause-every'], 10),
+  sleepFor: args['--pause-time'] && parseInt(args['--pause-time'], 10),
+  maxPerMinute: args['--rate'] && parseFloat(args['--rate'])
+};
+Object.keys(clientOptions).forEach(key => {
+  if (clientOptions[key] == null) { delete clientOptions[key]; }
+});
+
 const scraper = new Versionista({
   email: args['--email'],
-  password: args['--password']
+  password: args['--password'],
+  client: clientOptions
 });
 
 const isAfterMinimumDate = (testDate) => {

--- a/bin/scrape-versionista-and-email
+++ b/bin/scrape-versionista-and-email
@@ -20,6 +20,10 @@ Options:
   --sender-email STRING   E-mail address to send from. [env: SEND_ARCHIVES_FROM]
   --sender-password PASS  Password for e-mail account to send from. [env: SEND_ARCHIVES_PASSWORD]
   --receiver-email STRING E-mail address to send results to [env: SEND_ARCHIVES_TO]
+  --scrape-parallel NUM     Number of parallel connections to Versionista allowed.
+  --scrape-pause-every NUM  Pause briefly after this many requests to Versionista.
+  --scrape-pause-time MS    Milliseconds to pause for (see --scrape-pause-every)
+  --scrape-rate NUMBER      Maximum number of requests per minute
 `);
 
 const scriptsPath = __dirname;
@@ -64,6 +68,15 @@ function scrapeAccount() {
   const directory = path.join(outputDirectory, subdirectoryName);
   const errorFile = path.join(directory, `errors.log`);
 
+  const timingOptions = ['parallel', 'pause-every', 'pause-time', 'rate']
+    .reduce((result, name) => {
+      const value = args[`--scrape-${name}`];
+      if (value) {
+        result.push(`--${name}`, value);
+      }
+      return result;
+    }, []);
+
   return fs.ensureDir(directory)
     .then(() => run(
       path.join(scriptsPath, 'scrape-versionista'),
@@ -78,7 +91,7 @@ function scrapeAccount() {
         '--group-by-site',
         '--latest-version-only',
         '--skip-error-versions'
-      ]
+      ].concat(timingOptions)
     ))
     .then(process => {
       if (process.code === 0) {

--- a/bin/scrape-versionista-and-upload
+++ b/bin/scrape-versionista-and-upload
@@ -26,6 +26,10 @@ Options:
   --db-email STRING     Login e-mail for web-monitoring-db [env: WEB_MONITORING_EMAIL]
   --db-password STRING  Password for web-monitoring-db [env: WEB_MONITORING_PASSWORD]
   --db-url STRING       URL for web-monitoring-db instance [env: WEB_MONITORING_URL]
+  --scrape-parallel NUM     Number of parallel connections to Versionista allowed.
+  --scrape-pause-every NUM  Pause briefly after this many requests to Versionista.
+  --scrape-pause-time MS    Milliseconds to pause for (see --scrape-pause-every)
+  --scrape-rate NUMBER      Maximum number of requests per minute
 `);
 
 const scriptsPath = __dirname;
@@ -61,6 +65,15 @@ function archiveAndUpload (email, password, callback) {
       return callback(error);
     }
 
+    const timingOptions = ['parallel', 'pause-every', 'pause-time', 'rate']
+      .reduce((result, name) => {
+        const value = args[`--scrape-${name}`];
+        if (value) {
+          result.push(`--${name}`, value);
+        }
+        return result;
+      }, []);
+
     const scraper = spawn(
       path.join(scriptsPath, 'scrape-versionista'),
       [
@@ -74,7 +87,7 @@ function archiveAndUpload (email, password, callback) {
         '--relative-paths', path.join(outputDirectory),
         '--save-content',
         '--save-diffs'
-      ],
+      ].concat(timingOptions),
       {
         stdio: 'inherit'
       });

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,8 +7,9 @@ const USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/
 const SLEEP_EVERY = 40;
 const SLEEP_FOR = 1000;
 const MAX_RETRIES = 3;
+const MAX_PER_MINUTE = 0;
 
-function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepEvery = SLEEP_EVERY, sleepFor = SLEEP_FOR} = {}) {
+function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepEvery = SLEEP_EVERY, sleepFor = SLEEP_FOR, maxPerMinute = MAX_PER_MINUTE} = {}) {
   const cookieJar = request.jar();
   const versionistaRequest = request.defaults({
     jar: cookieJar,

--- a/lib/client.js
+++ b/lib/client.js
@@ -10,6 +10,8 @@ const MAX_RETRIES = 3;
 const MAX_PER_MINUTE = 0;
 
 function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepEvery = SLEEP_EVERY, sleepFor = SLEEP_FOR, maxPerMinute = MAX_PER_MINUTE} = {}) {
+  maxPerMinute = maxPerMinute || Infinity; // Allow 0 to imply Infinity
+
   const cookieJar = request.jar();
   const versionistaRequest = request.defaults({
     jar: cookieJar,
@@ -45,13 +47,34 @@ function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepE
   }
 
   let availableSockets = maxSockets;
+  let windowStart;
+  let windowSize = 60 * 1000; // 1 minute
+  let availableInWindow = maxPerMinute;
   const queue = [];
   function doNextRequest () {
     if (availableSockets <= 0 || sleeping) return;
 
+    const now = Date.now();
+    if (windowStart) {
+      const timeSinceWindowStart = now - windowStart;
+      if (timeSinceWindowStart > windowSize) {
+        windowStart = now - ((timeSinceWindowStart) % windowSize);
+        availableInWindow = maxPerMinute;
+      }
+    }
+    else {
+      windowStart = now;
+    }
+
+    if (availableInWindow <= 0) {
+      sleep( windowSize - (now - windowStart));
+      return;
+    }
+
     const task = queue.shift();
     if (task) {
       availableSockets--;
+      availableInWindow--;
       versionistaRequest(task.options, (error, response) => {
         availableSockets++;
         sleepIfNecessary();

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -59,7 +59,7 @@ class Versionista {
    * @param {String} options.password Password for Versionista account
    */
   constructor (options) {
-    this.client = createClient();
+    this.client = createClient(options && options.client || {});
     this.logIn = this.logIn.bind(this, options.email, options.password);
   }
 


### PR DESCRIPTION
Add timing and rate limiting options to the scraper. This mainly just exposes pre-existing options to the command line, but it does also add a system for rate limiting (only applied when using the `--rate` option).

Args are:

- `--parallel NUMBER` - Number of parallel connections to Versionista allowed. (Default: `6`)
- `--pause-every NUMBER` - Pause briefly after this many requests to Versionista. (Default: `40`)
- `--pause-time MS` - How long (in milliseconds) to pause for. (Default: `1000`)
- `--rate NUMBER` - Instead of the above, simply limit to this many requests per minute.

In the `scrape-and-upload` and `scrape-and-email` scripts, the above options are prefixed with `scrape`, e.g. `--scrape-rate`.

If any are unset, they just default to the values we’ve been using.