### PR TITLE
Change `errorCode` to `error_code` in imported data

### DIFF
--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -68,7 +68,7 @@ function importableVersion (version) {
       version_id: version.versionId,
       url: version.url,
       has_content: version.hasContent,
-      errorCode: version.is404Page ? '404' : version.errorCode,
+      error_code: version.is404Page ? '404' : version.errorCode,
       diff_with_previous_url: version.diffWithPreviousUrl,
       diff_with_first_url: version.diffWithFirstUrl,
       diff_hash: version.diff && version.diff.hash,

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -31,6 +31,8 @@ const {xpath, xpathArray, xpathNode} = require('./xpath');
  * @property {String} siteId
  * @property {String} url
  * @property {Date} date
+ * @property {Boolean} hasContent
+ * @property {Number} errorCode
  * @property {String} [diffWithPreviousUrl]
  * @property {Date} [diffWithPreviousDate]
  * @property {String} [diffWithFirstUrl]


### PR DESCRIPTION
The source_metadata for DB imports had an `errorCode` field, which was the only camel-cased (rather than snake-cased) field. Be consistent and make it snake-case.

We’ll add a migration on the DB side to fix historical data.