### PR TITLE
Sort by hashes and dates, to make it easier for analysts to organize changes

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -193,7 +193,7 @@ function csvStringForPages (pages) {
       ];
     })
     .sort(formatCsv.sortCsv)
-    .map((value, index) => {
+    .map((value, index) => { //sets Index column
       value[0] = index + 1;
       return value;
     });

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -167,31 +167,36 @@ function writeCsvsForSites (pagesBySite) {
 }
 
 function csvStringForPages (pages) {
-  let pageIndex = 1;
-  const rows = pages.map(page => {
-    const version = page.latest;
-    const metadata = version.source_metadata;
-    return [
-      pageIndex++,
-      version.uuid,
-      // TODO: format
-      timeString,
-      page.agency,
-      page.site,
-      page.title,
-      page.url,
-      `https://versionista.com/${metadata.site_id}/${metadata.page_id}/`,
-      metadata.diff_with_previous_url,
-      metadata.diff_with_first_url,
-      // TODO: format
-      formatCsv.formatDate(new Date(version.capture_time)),
-      '----',
-      metadata.diff_length,
-      metadata.diff_hash,
-      metadata.diff_text_length,
-      metadata.diff_text_hash
-    ];
-  });
+  const rows = pages
+    .map(page => {
+      const version = page.latest;
+      const metadata = version.source_metadata;
+      return [
+        '',
+        version.uuid,
+        // TODO: format
+        timeString,
+        page.agency,
+        page.site,
+        page.title,
+        page.url,
+        `https://versionista.com/${metadata.site_id}/${metadata.page_id}/`,
+        metadata.diff_with_previous_url,
+        metadata.diff_with_first_url,
+        // TODO: format
+        formatCsv.formatDate(new Date(version.capture_time)),
+        '----',
+        metadata.diff_length,
+        metadata.diff_hash,
+        metadata.diff_text_length,
+        metadata.diff_text_hash
+      ];
+    })
+    .sort(formatCsv.sortCsv)
+    .map((value, index) => {
+      value[0] = index + 1;
+      return value;
+    });
   return formatCsv.toCsvString([formatCsv.headers, ...rows]);
 }
 

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -449,7 +449,7 @@ let versions = pages
 
 
 let files;
-const completeData = versions.then(() => sites);
+const completeData = versions.then(() => sites)
 
 if (args['--output'] && args['--group-by-site']) {
   files = completeData

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -449,7 +449,7 @@ let versions = pages
 
 
 let files;
-const completeData = versions.then(() => sites)
+const completeData = versions.then(() => sites);
 
 if (args['--output'] && args['--group-by-site']) {
   files = completeData

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -6,7 +6,6 @@ require('../polyfill');
 const uuid = require('../uuid.js');
 
 const emptyHash = crypto.createHash('sha256').digest('hex');
-const sort = require('../sort');
 
 module.exports = formatCsv;
 
@@ -16,7 +15,7 @@ module.exports = formatCsv;
 function formatCsv (sites, options = {}) {
   const versionType = options.versionType || 'versions';
 
-  const rows = [headers];
+  const rows = [];
 
   if (options.includeDiffs) {
     rows[0].push('Diff File');
@@ -40,15 +39,13 @@ function formatCsv (sites, options = {}) {
   });
 
   const sortedRows = rows
-    .sort(sort)
-    .map((value, index) => {
-      if (value[0] !== "Index") {
-        value[0] = index;
-      }
-      return value
+    .sort(sortCsv)
+    .map((value, index) => { //sets Index column
+      value[0] = index + 1;
+      return value;
     });
 
-  return toCsvString(sortedRows);
+  return toCsvString([headers, ...sortedRows]);
 };
 
 const headers = [
@@ -188,29 +185,25 @@ function toCsvString (rows) {
 }
 
 function sortCsv (a, b) {
-  if (a[0] === "Index"){
-    return -1;
-  } else {
-    const a_text_hash = (a[15] || '').toLowerCase();
-    const b_text_hash = (b[15] || '').toLowerCase();
+  const a_text_hash = (a[15] || '').toLowerCase();
+  const b_text_hash = (b[15] || '').toLowerCase();
 
-    if (a_text_hash === b_text_hash) {
-      const a_diff_hash = (a[13] || '').toLowerCase();
-      const b_diff_hash = (b[13] || '').toLowerCase();
+  if (a_text_hash === b_text_hash) {
+    const a_diff_hash = (a[13] || '').toLowerCase();
+    const b_diff_hash = (b[13] || '').toLowerCase();
 
-      if (a_diff_hash === b_diff_hash) {
-        const a_time = new Date(a[10]);
-        const b_time = new Date(b[10]);
-        if (a_time === b_time) {
-          return 0;
-        }
-        return a_time < b_time ? -1 : 1;
+    if (a_diff_hash === b_diff_hash) {
+      const a_time = new Date(a[10]);
+      const b_time = new Date(b[10]);
+      if (a_time === b_time) {
+        return 0;
       }
-      return a_diff_hash < b_diff_hash ? -1 : 1;
+      return a_time < b_time ? -1 : 1;
     }
-    return a_text_hash < b_text_hash ? -1 : 1;
+    return a_diff_hash < b_diff_hash ? -1 : 1;
   }
-};
+  return a_text_hash < b_text_hash ? -1 : 1;
+}
 
 formatCsv.headers = headers;
 formatCsv.formatDate = formatDate;

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -38,7 +38,38 @@ function formatCsv (sites, options = {}) {
     });
   });
 
-  return toCsvString(rows);
+  const sortedRows = rows.sort((a, b) => {
+    if (a[0] === "Index"){
+      return -1;
+    } else {
+      const a_text_hash = a[15].toLowerCase();
+      const b_text_hash = b[15].toLowerCase();
+
+      if (a_text_hash === b_text_hash) {
+        const a_diff_hash = a[13].toLowerCase();
+        const b_diff_hash = b[13].toLowerCase();
+
+        if (a_diff_hash === b_diff_hash) {
+          const a_time = new Date(a[10]);
+          const b_time = new Date(b[10]);
+          if (a_time === b_time) {
+            return 0;
+          }
+          return a_time < b_time ? -1 : 1;
+        }
+        return a_diff_hash < b_diff_hash ? -1 : 1;
+      }
+      return a_text_hash < b_text_hash ? -1 : 1;
+    }
+  })
+  .map((value, index) => {
+    if (value[0] !== "Index") {
+      value[0] = index;
+    }
+    return value
+  });
+
+  return toCsvString(sortedRows);
 };
 
 const headers = [

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -6,6 +6,7 @@ require('../polyfill');
 const uuid = require('../uuid.js');
 
 const emptyHash = crypto.createHash('sha256').digest('hex');
+const sort = require('../sort');
 
 module.exports = formatCsv;
 
@@ -38,36 +39,14 @@ function formatCsv (sites, options = {}) {
     });
   });
 
-  const sortedRows = rows.sort((a, b) => {
-    if (a[0] === "Index"){
-      return -1;
-    } else {
-      const a_text_hash = a[15].toLowerCase();
-      const b_text_hash = b[15].toLowerCase();
-
-      if (a_text_hash === b_text_hash) {
-        const a_diff_hash = a[13].toLowerCase();
-        const b_diff_hash = b[13].toLowerCase();
-
-        if (a_diff_hash === b_diff_hash) {
-          const a_time = new Date(a[10]);
-          const b_time = new Date(b[10]);
-          if (a_time === b_time) {
-            return 0;
-          }
-          return a_time < b_time ? -1 : 1;
-        }
-        return a_diff_hash < b_diff_hash ? -1 : 1;
+  const sortedRows = rows
+    .sort(sort)
+    .map((value, index) => {
+      if (value[0] !== "Index") {
+        value[0] = index;
       }
-      return a_text_hash < b_text_hash ? -1 : 1;
-    }
-  })
-  .map((value, index) => {
-    if (value[0] !== "Index") {
-      value[0] = index;
-    }
-    return value
-  });
+      return value
+    });
 
   return toCsvString(sortedRows);
 };
@@ -208,7 +187,33 @@ function toCsvString (rows) {
     .join('\n');
 }
 
+function sortCsv (a, b) {
+  if (a[0] === "Index"){
+    return -1;
+  } else {
+    const a_text_hash = (a[15] || '').toLowerCase();
+    const b_text_hash = (b[15] || '').toLowerCase();
+
+    if (a_text_hash === b_text_hash) {
+      const a_diff_hash = (a[13] || '').toLowerCase();
+      const b_diff_hash = (b[13] || '').toLowerCase();
+
+      if (a_diff_hash === b_diff_hash) {
+        const a_time = new Date(a[10]);
+        const b_time = new Date(b[10]);
+        if (a_time === b_time) {
+          return 0;
+        }
+        return a_time < b_time ? -1 : 1;
+      }
+      return a_diff_hash < b_diff_hash ? -1 : 1;
+    }
+    return a_text_hash < b_text_hash ? -1 : 1;
+  }
+};
+
 formatCsv.headers = headers;
 formatCsv.formatDate = formatDate;
 formatCsv.toCsvString = toCsvString;
+formatCsv.sortCsv = sortCsv;
 

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -26,14 +26,11 @@ function formatCsv (sites, options = {}) {
     rows[0].push('Version Hash');
   }
 
-  let index = 1;
-
   // TODO: this would be better as a flatmap
   sites.forEach(site => {
     site.pages && site.pages.forEach(page => {
       page[versionType] && page[versionType].forEach(version => {
-        rows.push(rowForVersion(site, page, version, options, index));
-        index++;
+        rows.push(rowForVersion(site, page, version, options));
       });
     });
   });
@@ -67,12 +64,12 @@ const headers = [
   'Text Diff Hash'
 ];
 
-function rowForVersion (site, page, version, options, index) {
+function rowForVersion (site, page, version, options) {
   const diff = version.diff || {};
   const textDiff = version.textDiff || {};
 
   const row = [
-    index,
+    '',
     uuid(),
     formatDate(new Date(), true),
     agencyForSite(site),


### PR DESCRIPTION
Sorry, for the delay. Took a while for me to understand inputs and outputs and find the right test data, but I'm glad I got to dig into this and understand a bit about the scraper.

So, it looked like a good place to do the sorting was in the csv formatter right before rows are written to file. I adapted a comparator that mr0grog had worked on. I also re-calculated indexes after sorting. 

Initially, I tried changing `rowForVersion` to not accept and set `index` because we overwrite it, but ran into errors when adding the columns and running the comparator. So, I settled on just overwriting and leaving that function alone.