### PR TITLE
HOTFIX: get raw content version-by-version (instead of zip archives)

### DIFF
--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -277,62 +277,25 @@ function archivePageVersions (page, versions) {
   }
 
   const siteId = versions[0].siteId;
-  const unmatchedVersions = new Set(downloadableVersions);
-
   const pageDirectory = `${siteId}-${page.id}`;
   const pagePath = path.join(baseDirectory, pageDirectory);
 
   return fs.ensureDir(pagePath)
-    .then(() => new Promise((resolve, reject) => {
-      scraper.getVersionArchiveEntries(page.versionistaUrl)
-        .on('error', reject)
-        .pipe(stream.Transform({
-          objectMode: true,
-          transform: function (entry, encoding, callback) {
-            entry.resume();
-            // Frustratingly, the timestamps on the files do not
-            // match the timestamps on the version records. So...
-            // find the closest matching timestamp, but also require
-            // it to be within a narrow threshold.
-            const allowableTimeframe = 30 * 60 * 1000;
-            const fileVersion = minimum(unmatchedVersions, version => {
-              const timeApart = Math.abs(version.date - entry.date);
-              return (timeApart < allowableTimeframe) ? timeApart : null;
-            });
+    .then(() => {
+      const downloads = downloadableVersions.map(version => {
+        return scraper.getVersionRawContent(version.url)
+          .then(content => {
+            let name = `version-${version.versionId}${content.extension}`;
+            let outputPath = path.join(pagePath, name);
 
-            let outputPath = path.join(pagePath, entry.path);
-            if (fileVersion) {
-              let name = `version-${fileVersion.versionId}${entry.extension}`;
-              outputPath = path.join(pagePath, name);
+            version.filePath = getCleanedPath(outputPath);
+            version.hash = content.hash;
 
-              unmatchedVersions.delete(fileVersion);
-              fileVersion.filePath = getCleanedPath(outputPath);
-              entry.on('hash', hash => fileVersion.hash = hash.toString('hex'));
-            }
-            else if (args['--save-content'] !== 'all') {
-              entry.autodrain();
-              return callback();
-            }
-
-            entry
-              .pipe(fs.createWriteStream(outputPath))
-              .on('error', callback)
-              .on('finish', callback);
-          }
-        }))
-        .resume()
-        .on('error', reject)
-        .on('end', () => {
-          if (unmatchedVersions.size > 0) {
-            const ids = Array.from(unmatchedVersions).map(v => v.versionId);
-            return reject(new Error(`${unmatchedVersions.size} versions not found in downloaded archive: ${ids} (Page ${page.id})`));
-          }
-          resolve();
-        })
-    }))
-    .catch(error => {
-      // emit messages here and allow the process to continue
-      logError(error);
+            return fs.writeFile(outputPath, content.body);
+          })
+          .catch(logError);
+      });
+      return Promise.all(downloads);
     });
 }
 

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const stream = require('stream');
 const Entities = require('html-entities').AllHtmlEntities;
 const jsdom = require('jsdom');
+const mime = require('mime-types');
 const unzip = require('unzip-stream');
 const createClient = require('./client');
 const flatten = require('./flatten');
@@ -108,6 +109,10 @@ class Versionista {
               }
             });
           });
+        }
+        else if (options.stringifyHtml && mightBeHtml) {
+          response.body = response.body.toString();
+          return response;
         }
         else {
           return response;
@@ -283,7 +288,7 @@ class Versionista {
     // The "api" for this is available directly at versionista.com.
     const apiUrl = versionUrl.replace(
       /(versionista.com\/)(.*)$/,
-      '$1api/ip_url/$2/html');
+      '$1api/ip_url/$2/raw');
 
     return this.request({url: apiUrl, parseBody: false})
       .then(response => {
@@ -299,7 +304,8 @@ class Versionista {
           immediate: true,
           // A version may be binary data (for PDFs, videos, etc.)
           encoding: null,
-          parseBody: false
+          parseBody: false,
+          stringifyHtml: true
         });
       })
       // The raw source is the text of the `<pre>` element. A different type of
@@ -307,33 +313,52 @@ class Versionista {
       // but it appears that the source there has been parsed, cleaned up
       // (made valid HTML), and had Versionista analytics inserted.
       .then(response => {
+        const hash = crypto.createHash('sha256');
+        hash.update(response.body);
+        let mimeExtension = mime.extension(response.headers['content-type']);
+        const result = {
+          headers: response.headers,
+          body: response.body,
+          extension: mimeExtension ? `.${mimeExtension}` : '',
+          hash: hash.digest('hex')
+        };
+
         // Sometimes a version may have no content (e.g. a page was removed).
         // This is OK.
         if (response.body.toString() === '') {
-          return '';
+          return Object.assign(result, {body: ''});
         }
         // Are we dealing with HTML?
         else if (typeof response.body === 'string') {
-          // we don't actually parse this content with JSDOM because it could be
-          // big enough to consume all our available memory. Instead, do some
-          // dumb, simplistic decoding.
-          const openPreIndex = response.body.indexOf('<pre>');
-          const closePreIndex = response.body.indexOf('</pre>', openPreIndex);
-          if (openPreIndex > -1 && closePreIndex > -1) {
-            const formattedContent = response.body.slice(
-              openPreIndex + 5,
-              closePreIndex);
-            const encodedContent = formattedContent.replace(/<[^>]+>/g, '');
-            const entities = new Entities();
-            return entities.decode(encodedContent);
+          let source = response.body;
+
+          if (/^<h\d>Cache expired<\/h\d>/i.test(source)) {
+            // fall through to the error if there are no more retries
+            if (retries) {
+              return this.getVersionRawContent(versionUrl, retries - 1);
+            }
           }
-          // Handle cache timeout (see note on temporary URLs above)
-          else if (document.body.textContent.match(/cache expired/i) && retries) {
-            return this.getVersionRawContent(versionUrl, retries - 1);
+          else {
+            // For some reason Versionista seems to insert some blank lines
+            if (source.startsWith('\n\n\n')) {
+              source = source.slice(3);
+            }
+            // Clear out Versionista additions (even though there's nothing
+            // actually between these comments in `raw` responses).
+            const startMarker = '\n<!-- Versionista general -->';
+            const endMarker = '<!-- End Versionista general -->\n';
+            const insertionStart = source.indexOf(startMarker);
+            const insertionEnd = source.indexOf(endMarker);
+            if (insertionStart > -1 && insertionEnd > -1) {
+              source = source.slice(0, insertionStart) +
+                source.slice(insertionEnd + endMarker.length);
+            }
+
+            return Object.assign(result, {body: source});
           }
         }
         else if (Buffer.isBuffer(response.body)) {
-          return response.body;
+          return result;
         }
 
         // FAILURE!

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "html-entities": "^1.2.0",
     "jsdom": "^9.12.0",
     "klaw": "^1.3.1",
-    "mime-types": "^2.1.15",
+    "mime-types": "^2.1.17",
     "mkdirp": "^0.5.1",
     "neodoc": "^1.4.0",
     "nodemailer": "^4.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -816,11 +816,21 @@ mime-db@~1.27.0:
   version "1.27.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
-mime-types@^2.0.8, mime-types@^2.1.12, mime-types@^2.1.15, mime-types@~2.1.7:
+mime-db@~1.30.0:
+  version "1.30.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
+
+mime-types@^2.0.8, mime-types@^2.1.12, mime-types@~2.1.7:
   version "2.1.15"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
     mime-db "~1.27.0"
+
+mime-types@^2.1.17:
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
+  dependencies:
+    mime-db "~1.30.0"
 
 mime@^1.2.11:
   version "1.3.4"


### PR DESCRIPTION
The zip archive functionality appears to have been removed (or removed specially for us!), so retrieve raw content version by version, similar to how we retrieve diffs. This was our very original approach, but had issues around file naming, exactitude of content, etc, so we abandoned it in favor of the zip archives, which were a better guarantee. This seems to be working alright now, though.