### PR TITLE
HOTFIX: ensure hash is calculated from final body

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -313,20 +313,21 @@ class Versionista {
       // but it appears that the source there has been parsed, cleaned up
       // (made valid HTML), and had Versionista analytics inserted.
       .then(response => {
-        const hash = crypto.createHash('sha256');
-        hash.update(response.body);
         let mimeExtension = mime.extension(response.headers['content-type']);
-        const result = {
-          headers: response.headers,
-          body: response.body,
-          extension: mimeExtension ? `.${mimeExtension}` : '',
-          hash: hash.digest('hex')
+        const buildResult = (extras) => {
+          const result = Object.assign({
+            headers: response.headers,
+            body: response.body,
+            extension: mimeExtension ? `.${mimeExtension}` : ''
+          }, extras);
+          result.hash = hash(result.body);
+          return result;
         };
 
         // Sometimes a version may have no content (e.g. a page was removed).
         // This is OK.
         if (response.body.toString() === '') {
-          return Object.assign(result, {body: ''});
+          return buildResult({body: ''});
         }
         // Are we dealing with HTML?
         else if (typeof response.body === 'string') {
@@ -354,11 +355,11 @@ class Versionista {
                 source.slice(insertionEnd + endMarker.length);
             }
 
-            return Object.assign(result, {body: source});
+            return buildResult({body: source});
           }
         }
         else if (Buffer.isBuffer(response.body)) {
-          return result;
+          return buildResult({body: response.body});
         }
 
         // FAILURE!


### PR DESCRIPTION
We were accidentally hashing the raw response, but we do some later manipulations to clean that response up, meaning it won't match the hash :(