### PR TITLE
Stop checking Versionista `since` column

### DIFF
--- a/bin/get-versionista-metadata
+++ b/bin/get-versionista-metadata
@@ -194,18 +194,35 @@ const isBeforeMaximumDate = (testDate) => {
   return !args['--before'] || args['--before'] >= testDate;
 };
 
+/**
+ * Test whether a date object or object with a date attached (e.g. site, page,
+ * version) is within the requested timeframe. Note that this *will* return
+ * `true` if the object is undated (that is, it has a field for the date, but
+ * that field is not filled in).
+ * @param {Date|VersionistaVersion|VersionistaPage|VersionistaSite} testDate
+ */
 const isInRequestedDateRange = (testDate) => {
   if (testDate instanceof Date) {
     return isAfterMinimumDate(testDate) && isBeforeMaximumDate(testDate);
   }
-  else if (testDate.date) {
-    return isInRequestedDateRange(testDate.date);
+  else if ('date' in testDate) {
+    return testDate.date ? isInRequestedDateRange(testDate.date) : true;
   }
-  else if (testDate.lastChange) {
-    return isAfterMinimumDate(testDate.lastChange);
+  else if ('lastChange' in testDate) {
+    return testDate.lastChange ? isAfterMinimumDate(testDate.lastChange) : true;
   }
   throw new Error(`Cannot apply date filter to: ${JSON.stringify(testDate)}`);
 }
+
+/**
+ * Test whether a page might possibly contain some versions based on its
+ * `totalVersions` field. If we can determine it has no versions, there's no
+ * reason to scrape it. Will return `true` if `totalVersions` is unknown.
+ * @param {VersionistaPage} page
+ * @returns {boolean}
+ */
+const mayHaveVersions = (page) =>
+  Number.isNaN(page.totalVersions) || page.totalVersions > 0;
 
 const formatter = formatters[args['--format']] || formatters.json;
 const startTime = Date.now();
@@ -224,6 +241,7 @@ let pages = sites
     // return Promise.all(sites.map(site => scraper.getPages(site.url)));
     const pagesForSites = sites.map(site => {
       return scraper.getPages(site.url)
+        .then(pages => pages.filter(mayHaveVersions))
         .then(pages => pages.filter(isInRequestedDateRange))
         .then(pages => {
           site.pages = pages;

--- a/bin/get-versionista-page-chunk
+++ b/bin/get-versionista-page-chunk
@@ -398,6 +398,14 @@ let versions = pages
       }
 
       const pageVersions = scraper.getVersions(page.versionistaUrl)
+        // Log errors, but do not fail if no date could be found for a version.
+        .then(versions => versions.filter(version => {
+          if (!version.date) {
+            logError(`No date found for version: ${JSON.stringify(version)}`);
+            return false;
+          }
+          return true;
+        }))
         .then(versions => versions.filter(isInRequestedDateRange));
 
       // Note the flipped order of filtering latest between errors and

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -352,6 +352,14 @@ let versions = pages
       }
 
       const pageVersions = scraper.getVersions(page.versionistaUrl)
+        // Log errors, but do not fail if no date could be found for a version.
+        .then(versions => versions.filter(version => {
+          if (!version.date) {
+            logError(`No date found for version: ${JSON.stringify(version)}`);
+            return false;
+          }
+          return true;
+        }))
         .then(versions => versions.filter(isInRequestedDateRange));
 
       // Note the flipped order of filtering latest between errors and

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -204,6 +204,9 @@ const isInRequestedDateRange = (testDate) => {
   else if (testDate.lastChange) {
     return isAfterMinimumDate(testDate.lastChange);
   }
+  else if (testDate.lastChange === null) {
+    return true;
+  }
   throw new Error(`Cannot apply date filter to: ${JSON.stringify(testDate)}`);
 }
 

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -194,18 +194,22 @@ const isBeforeMaximumDate = (testDate) => {
   return !args['--before'] || args['--before'] >= testDate;
 };
 
+/**
+ * Test whether a date object or object with a date attached (e.g. site, page,
+ * version) is within the requested timeframe. Note that this *will* return
+ * `true` if the object is undated (that is, it has a field for the date, but
+ * that field is not filled in).
+ * @param {Date|VersionistaVersion|VersionistaPage|VersionistaSite} testDate
+ */
 const isInRequestedDateRange = (testDate) => {
   if (testDate instanceof Date) {
     return isAfterMinimumDate(testDate) && isBeforeMaximumDate(testDate);
   }
-  else if (testDate.date) {
-    return isInRequestedDateRange(testDate.date);
+  else if ('date' in testDate) {
+    return testDate.date ? isInRequestedDateRange(testDate.date) : true;
   }
-  else if (testDate.lastChange) {
-    return isAfterMinimumDate(testDate.lastChange);
-  }
-  else if (testDate.lastChange === null) {
-    return true;
+  else if ('lastChange' in testDate) {
+    return testDate.lastChange ? isAfterMinimumDate(testDate.lastChange) : true;
   }
   throw new Error(`Cannot apply date filter to: ${JSON.stringify(testDate)}`);
 }

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -214,6 +214,16 @@ const isInRequestedDateRange = (testDate) => {
   throw new Error(`Cannot apply date filter to: ${JSON.stringify(testDate)}`);
 }
 
+/**
+ * Test whether a page might possibly contain some versions based on its
+ * `totalVersions` field. If we can determine it has no versions, there's no
+ * reason to scrape it. Will return `true` if `totalVersions` is unknown.
+ * @param {VersionistaPage} page
+ * @returns {boolean}
+ */
+const mayHaveVersions = (page) =>
+  Number.isNaN(page.totalVersions) || page.totalVersions > 0;
+
 const formatter = formatters[args['--format']] || formatters.json;
 const startTime = Date.now();
 
@@ -320,6 +330,7 @@ let pages = sites
     // return Promise.all(sites.map(site => scraper.getPages(site.url)));
     const pagesForSites = sites.map(site => {
       return scraper.getPages(site.url)
+        .then(pages => pages.filter(mayHaveVersions))
         .then(pages => pages.filter(isInRequestedDateRange))
         .then(pages => {
           site.pages = pages;

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -23,6 +23,7 @@ const {xpath, xpathArray, xpathNode} = require('./xpath');
  * @property {String} versionistaUrl
  * @property {String} title
  * @property {Date} lastChange
+ * @property {Number} totalVersions
  */
 
 /**
@@ -627,24 +628,37 @@ function getPageDetailData (window) {
   const xpathRows = xpath(window.document, "//div[contains(text(), 'URL')]/../../../following-sibling::tbody/tr");
   return xpathRows.map(row => {
     const updateTimeText = parseFloat(xpathNode(row, "./td[9]").textContent.trim());
+    const totalVersions = parseFloat(xpathNode(row, "./td[7]").textContent.trim());
     const updateTime = (Number.isNaN(updateTimeText)) ? null : new Date(1000 * updateTimeText);
     const remoteLink = xpathNode(row, "./td[a][1]/a").href;
     // NOTE: the URL is not encoded here (!)
     const remoteUrl = remoteLink.slice(remoteLink.indexOf('?') + 1);
     const versionistaUrl = xpathNode(row, "./td[a][2]/a").href;
 
+    // Sanity-check totalVersions
+    if (!Number.isNaN(totalVersions) && totalVersions > 10000) {
+      throw new Error(oneLine(`A number was found for totalVersions, but it doesn’t
+        look like an actual version count! Versionista’s UI may have changed.
+        (${versionistaUrl})`));
+    }
+
     return {
       id: parseVersionistaUrl(versionistaUrl).pageId,
       url: remoteUrl,
       versionistaUrl: versionistaUrl,
       title: xpathNode(row, "./td[a][3]").textContent.trim(),
-      lastChange: updateTime
+      lastChange: updateTime,
+      totalVersions
     };
   });
 };
 
 function versionDataFromLink (versionLink) {
 
+}
+
+function oneLine (string) {
+  return string.replace(/\n\s+/g, ' ');
 }
 
 module.exports = Versionista;

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -208,7 +208,8 @@ class Versionista {
     const versionDataForRow = (versionRow) => {
       const dateNode = xpathNode(versionRow, "./td[2]//*[@class='gmt']");
       const linkNode = xpathNode(versionRow, "./td[2]/a");
-      const date = new Date(1000 * parseFloat(dateNode.textContent));
+      const timestamp = 1000 * parseFloat(dateNode.textContent);
+      const date = Number.isNaN(timestamp) ? null : new Date(timestamp);
 
       let url = linkNode && linkNode.href;
       let hasContent = !!url;

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -157,13 +157,15 @@ class Versionista {
           const link = row.querySelector('a.kwbase');
           const updateElement = row.querySelector('.kwlastChange');
           const lastUpdateSecondsAgo =
-            updateElement ? parseFloat(updateElement.textContent) : Infinity;
+            updateElement ? parseFloat(updateElement.textContent) : NaN;
 
           return {
             id: parseVersionistaUrl(link.href).siteId,
             name: link.textContent.trim(),
             url: link.href,
-            lastChange: new Date(window.requestDate - lastUpdateSecondsAgo * 1000)
+            lastChange: (Number.isNaN(lastUpdateSecondsAgo))
+              ? null
+              : new Date(window.requestDate - lastUpdateSecondsAgo * 1000)
           };
         });
       });
@@ -624,7 +626,7 @@ function getPageDetailData (window) {
   const xpathRows = xpath(window.document, "//div[contains(text(), 'URL')]/../../../following-sibling::tbody/tr");
   return xpathRows.map(row => {
     const updateTimeText = parseFloat(xpathNode(row, "./td[9]").textContent.trim());
-    const updateTime = new Date(1000 * updateTimeText);
+    const updateTime = (Number.isNaN(updateTimeText)) ? null : new Date(1000 * updateTimeText);
     const remoteLink = xpathNode(row, "./td[a][1]/a").href;
     // NOTE: the URL is not encoded here (!)
     const remoteUrl = remoteLink.slice(remoteLink.indexOf('?') + 1);


### PR DESCRIPTION
**WIP** Fixes #51 

I think I hit the problems outlined in the issue. But not sure if it's working correctly. The scraper runs for an inordinate amount of time (*20+ min and hasn't finished yet*) within a tiny `--before` and `--after` timeframe (*interval of 10 min*), but that might be because of having 
>to visit every page tracked by Versionista. :(

@Mr0grog Can you merge in the backfill tools? I can fix them up if the changes look correct.
We may have to break up the backfilling work if it's going to take as long as I imagine =(
