### PR TITLE
Fix Versionista metadata showing up in our "raw" content

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -52,6 +52,9 @@ const {xpath, xpathArray, xpathNode} = require('./xpath');
  * @property {String} content The diff itself
  */
 
+const versionistaSourceAdditionsPattern =
+  /\n?<!--\s*Versionista general\s*-->[^]*?<!--\s*End Versionista general\s*-->\n?/i;
+
 /**
  * Provides access to data from a Versionista account.
  */
@@ -350,14 +353,7 @@ class Versionista {
             }
             // Clear out Versionista additions (even though there's nothing
             // actually between these comments in `raw` responses).
-            const startMarker = '\n<!-- Versionista general -->';
-            const endMarker = '<!-- End Versionista general -->\n';
-            const insertionStart = source.indexOf(startMarker);
-            const insertionEnd = source.indexOf(endMarker);
-            if (insertionStart > -1 && insertionEnd > -1) {
-              source = source.slice(0, insertionStart) +
-                source.slice(insertionEnd + endMarker.length);
-            }
+            source = source.replace(versionistaSourceAdditionsPattern, '');
 
             return buildResult({body: source});
           }
@@ -563,15 +559,9 @@ class Versionista {
         // metadata, scripting and styling
         let hashableBody = response.body || '';
         if (typeof hashableBody === 'string') {
-          const startMarker = '<!-- Versionista general -->';
-          const endMarker = '<!-- End Versionista general -->\n';
-          const insertionStart = hashableBody.indexOf(startMarker);
-          const insertionEnd = hashableBody.indexOf(endMarker);
-          if (insertionStart > -1 && insertionEnd > -1) {
-            hashableBody = hashableBody.slice(0, insertionStart) +
-              hashableBody.slice(insertionEnd + endMarker.length);
-          }
-          hashableBody = hashableBody.trim();
+          hashableBody = hashableBody
+            .replace(versionistaSourceAdditionsPattern, '')
+            .trim();
         }
 
         return {


### PR DESCRIPTION
It turns out our old exact-match check for the additions Versionista makes to the raw HTML source of a version broke a while ago, so we have source now that does not match the original server response anymore. This Fixes the issue when gathering new content by using a regular expression that is a little more flexible.

Fixes #56.

We still have to go clean up all our old records after this is merged and deployed :\

**Note: depends on #53**