### PR TITLE
Add `--before` option to `scrape-versionista-and-email` script

### DIFF
--- a/bin/scrape-versionista-and-email
+++ b/bin/scrape-versionista-and-email
@@ -13,6 +13,7 @@ Usage: scrape-versionista-and-email [options]
 Options:
   -h, --help              Print this lovely help message.
   --after HOURS           Only include versions from N hours ago. [default: 72]
+  --before HOURS          Only include versions before N hours ago. [default: 0]
   --output DIRECTORY      Write output to this directory.
   --email STRING          Versionista account e-mail address [env: VERSIONISTA_EMAIL]
   --password STRING       Versionista account password [env: VERSIONISTA_PASSWORD]
@@ -85,6 +86,7 @@ function scrapeAccount() {
         '--password', versionista.password,
         '--account-name', versionista.name,
         '--after', args['--after'],
+        '--before', args['--before'],
         '--format', 'csv',
         '--output', path.join(directory, `whatever.csv`),
         '--errors', errorFile,


### PR DESCRIPTION
These changes were sitting on the server and I think I'd used them for some sort of remediation. They are probably also being used for the health team scraping. Figured I should get them off the server and into our source code! (Dunno how I missed doing this *long* ago.)