### PR TITLE
Add byte length, content type, and headers to Version data

### DIFF
--- a/bin/get-versionista-page-chunk
+++ b/bin/get-versionista-page-chunk
@@ -292,6 +292,9 @@ function archivePageVersions (page, versions) {
 
             version.filePath = getCleanedPath(outputPath);
             version.hash = content.hash;
+            version.length = content.length;
+            version.headers = content.headers;
+            version.contentType = content.headers['content-type'];
 
             return fs.writeFile(outputPath, content.body);
           })

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -74,7 +74,10 @@ function importableVersion (version) {
       diff_hash: version.diff && version.diff.hash,
       diff_length: version.diff && version.diff.length,
       diff_text_hash: version.textDiff && version.textDiff.hash,
-      diff_text_length: version.textDiff && version.textDiff.length
+      diff_text_length: version.textDiff && version.textDiff.length,
+      length: version.length,
+      headers: version.headers,
+      content_type: version.contentType
     }
   };
 }

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -307,6 +307,9 @@ function archivePageVersions (page, versions) {
 
             version.filePath = getCleanedPath(outputPath);
             version.hash = content.hash;
+            version.length = content.length;
+            version.headers = content.headers;
+            version.contentType = content.headers['content-type'];
 
             return fs.writeFile(outputPath, content.body);
           })

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -318,6 +318,7 @@ class Versionista {
             extension: mimeExtension ? `.${mimeExtension}` : ''
           }, extras);
           result.hash = hash(result.body);
+          result.length = Buffer.byteLength(result.body, 'utf8');
           return result;
         };
 


### PR DESCRIPTION
This adds three keys to scraped/imported version data:

- `length` (number of bytes)
- `content_type` (camel case in scraper output, snake case in imports)
- `headers` (headers of raw version from Versionista)

I think I may have decided not to include `headers` before because it’s *mostly* Versionista-specific stuff and not relevant info from the capture (the way archive.org does it):

```js
"headers": {
  "age": "0",
  "date": "Wed, 17 Jan 2018 07:16:51 GMT",
  "vary": "Accept-Encoding",
  "expires": "Wed, 17 Jan 2018 07:16:51 GMT",
  "x-cachee": "MISS",
  "connection": "close",
  "content-type": "text/html; charset=UTF-8",
  "accept-ranges": "bytes",
  "cache-control": "private, max-age=0",
  "transfer-encoding": "chunked"
}
```

…but figured we may as well just include it all (easier to throw it out later than not have it when we want it). At the very least, the `content-type` header is salient and important.

I have no idea why I never included content type (since I had it already in order to generate the file extension) or the byte length. Those seems like no-brainers to have included ¯\\\_(ツ)\_/¯ 