### PR TITLE
Add `--update` option to `import-to-db` script to match import API

### DIFF
--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -29,6 +29,9 @@ Options:
                    [default: edgi-versionista-archive]
                    [env: AWS_S3_BUCKET]
   --chunk SIZE     Send versions in chunks of this size. [default: 1000]
+  --update UPDATE  Set the update behavior, which determines how versions that
+                   are already in the database are treated. Should be one of
+                   'skip' (default), 'merge', or 'replace'.
 `);
 
 const dbUrl = composeUrl(
@@ -224,11 +227,14 @@ function composeUrl (sourceUrl, user, password, tail = '') {
 }
 
 function importIntoDb (versions, callback) {
+  const qs = args['--update'] ? {update: args['--update']} : {};
+
   request({
     method: 'POST',
     url: dbUrl,
     headers: {'Content-Type': 'application/x-json-stream'},
-    body: versions.map(v => JSON.stringify(v)).join('\n')
+    body: versions.map(v => JSON.stringify(v)).join('\n'),
+    qs
   }, (error, response, rawBody) => {
     if (error) {
       return callback(error)


### PR DESCRIPTION
The value of this option determines how versions that are already present in the DB are handled:

- `--update skip`: Skip the version (since we already have it) (default)
- `--update replace`: Replace the old version's data with the import data
- `--udpate merge`: Merge the import data into the existing data (fields that are missing in the import will stay the way they already were in the DB; this also happens in a recursive sense with the `source_metadata` field)