### PR TITLE
HOTFIX: handle missing Versionista links

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -140,10 +140,10 @@ function createViewUrl (page, toVersion, fromVersion, useVersionista) {
     else if (toVersion) {
       url = metadata.diff_with_previous_url;
     }
-    if (!url.endsWith('/')) {
+    if (url && !url.endsWith('/')) {
       url = url + '/';
     }
-    return url;
+    return url || '';
   }
 
   let url = `${uiUrl}page/${page.uuid}/`;


### PR DESCRIPTION
If a version was the first, there is no precalculated comparison link. Thought I had committed this work weeks ago :(