### PR TITLE
Replace *.herokuapp.com references with proper api.monitoring.envirodatagov.org references

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -28,4 +28,4 @@ export SEND_ARCHIVES_TO='abc@gmail.com, def@example.com'
 export WEB_MONITORING_EMAIL=zzz@gmail.com
 export WEB_MONITORING_PASSWORD=XYZ
 # NOTE: no need to specify this if at the default URL as below
-export WEB_MONITORING_URL=http://web-monitoring-db.herokuapp.com/
+export WEB_MONITORING_URL=https://api.monitoring.envirodatagov.org/

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -23,7 +23,7 @@ Options:
   --password PASS  PASSWORD for web-monitoring-db [env: WEB_MONITORING_PASSWORD]
   --host HOST      Alternate host name for web-monitoring-db. Use this to send
                    data to an alternate instance of the DB.
-                   [default: https://web-monitoring-db.herokuapp.com/]
+                   [default: https://api.monitoring.envirodatagov.org/]
                    [env: WEB_MONITORING_URL]
   --bucket BUCKET  Amazon S3 bucket that is hosting raw version data.
                    [default: edgi-versionista-archive]


### PR DESCRIPTION
Pretty much just what it says on the tin. Replace references to deprecated domains.