### PR TITLE
Use `sites`, `maintainers` and `title` fields that were added to DB

### DIFF
--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -57,9 +57,9 @@ function importableVersion (version) {
 
   return {
     page_url: version.pageUrl,
-    page_title: version.pageTitle,
-    site_agency: version.agency,
-    site_name: version.siteName,
+    page_maintainers: [version.agency],
+    page_tags: [`site:${version.siteName}`],
+    title: version.pageTitle,
     capture_time: version.date,
     uri: s3Url,
     version_hash: version.hash,

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -172,12 +172,13 @@ function getSiteUpdates () {
       if (linkToVersionista) return pages;
 
       return parallelMap(page => {
-        return getAllResults(`/api/v0/pages/${page.uuid}/versions`, {
+        return getResponse(`/api/v0/pages/${page.uuid}/versions`, {
           source_type: 'versionista',
-          chunk_size: 1000
+          sort: 'capture_time:asc',
+          chunk_size: 1,
         })
-          .then(versions => {
-            page.earliest = versions[versions.length - 1];
+          .then(body => {
+            page.earliest = body.data[0];
             return page;
           });
       }, 10, pages);
@@ -402,8 +403,7 @@ function getCredentialsFromUrl (url) {
   return null;
 }
 
-// Get all pages of a result set from the given API endpoint and query data
-function getAllResults (apiPath, qs) {
+function getResponse (apiPath, qs) {
   const requestOptions = {qs};
   if (dbCredentials) {
     requestOptions.auth = dbCredentials;
@@ -412,6 +412,10 @@ function getAllResults (apiPath, qs) {
   return new Promise((resolve, reject) => {
     const url = /^http(s?):\/\//.test(apiPath) ? apiPath : `${dbUrl}${apiPath}`;
     request.get(url, requestOptions, function(error, response) {
+      if (args['--debug']) {
+        console.log(`Got ${url}`);
+      }
+
       if (error) return reject(error);
 
       let body;
@@ -427,27 +431,32 @@ function getAllResults (apiPath, qs) {
         return reject(body.errors[0]);
       };
 
+      resolve(body);
+    });
+  });
+}
+
+function delayPromise (timeout) {
+  return new Promise(done => timeout ? setTimeout(done, timeout) : done());
+}
+
+// Get all pages of a result set from the given API endpoint and query data
+function getAllResults (apiPath, qs) {
+  return getResponse(apiPath, qs)
+    .then(body => {
       if (args['--debug']) {
         console.log(`Got ${getChunk(apiPath)} of ${getChunk(body.links.last)}`);
       }
 
       // Concatenate the next page onto the end of this one if there is one.
       if (body.links.next) {
-        const next = () => resolve(
-          getAllResults(body.links.next)
-            .then(nextPages => body.data.concat(nextPages)));
-
-        if (chunkDelay) {
-          setTimeout(next, chunkDelay);
-        }
-        else {
-          next();
-        }
-        return;
+        return delayPromise(chunkDelay || 0)
+          .then(() => getAllResults(body.links.next))
+          .then(nextPages => body.data.concat(nextPages));
       }
-      resolve(body.data);
+
+      return body.data;
     });
-  });
 }
 
 // Map an async transform function to each item of an array in parallel
@@ -479,7 +488,7 @@ function parallelMap (transform, parallelOperations, data) {
     };
 
     // Start working on as many items as possible
-    while (inProgress < parallelOperations) {
+    while (inProgress < Math.min(data.length, parallelOperations)) {
       transformNextItem();
     }
   });

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -33,6 +33,11 @@ Options:
   --debug                 Print debug messages
 `);
 
+process.on('unhandledRejection', (reason, p) => {
+  console.error('Unhandled Rejection at:', p, 'reason:', reason);
+  console.error(reason.stack);
+});
+
 const scriptsPath = __dirname;
 const outputParent = path.resolve(args['--output']);
 const dbUrl = (args['--db-url'])
@@ -180,21 +185,31 @@ function getSiteUpdates () {
     // Group pages by site
     .then(pages => {
       pages.forEach(page => {
+        page.sites = page.tags
+          .filter(tag => tag.name.startsWith('site:'))
+          .map(tag => tag.name.replace(/^site:/, ''));
+        if (page.sites.length === 0) {
+          page.sites = ['no site'];
+        }
+
         const latest = page.versions[0];
         page.latest = latest;
-        const group = isError(latest) ? 'errors' : page.site;
-        pagesBySite.add(group, page);
 
         // Check whether there was also a non-error version that we should show
         if (isError(latest)) {
+          pagesBySite.add('errors', page);
+
           for (let i = 1, len = page.versions.length; i < len; i++) {
             const version = page.versions[i];
             if (!isError(version)) {
               const nonErrorPage = Object.assign({}, page, {latest: version});
-              pagesBySite.add(page.site, nonErrorPage);
+              page.sites.forEach(site => pagesBySite.add(site, nonErrorPage));
               break;
             }
           }
+        }
+        else {
+          page.sites.forEach(site => pagesBySite.add(site, page));
         }
       });
 
@@ -231,8 +246,8 @@ function csvStringForPages (pages) {
         version.uuid,
         // TODO: format
         timeString,
-        page.agency,
-        page.site,
+        page.maintainers.map(maintainer => maintainer.name).join(', '),
+        page.sites.join(', '),
         page.title,
         page.url,
         // for now, the "page view" link is always to Versionista


### PR DESCRIPTION
When importing data, use `title` (instead of `page_title`, `maintainers` (instead of `agency`) and `tags` (instead of `site`).

When querying, read the `maintainers` and `tags` instead of `agency` and `site` fields. Pages that have multiple entries in those lists will show the results as comma-separated in the outputted CSVs.

As a final bonus, use the [new sorting functionality](https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/225) to speed up queries a bit and lessen the load on DB. (It would be nice to use `^..{id}` links and save a HUGE amount of work, but we still need to figure out what *date* to put in the spreadsheet :\ )

Fixes #69.