### PR TITLE
HOTFIX: handle original/live page links that don’t redirect

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -611,10 +611,20 @@ function getPageDetailData (window) {
     const updateTimeText = parseFloat(xpathNode(row, "./td[9]").textContent.trim());
     const totalVersions = parseFloat(xpathNode(row, "./td[7]").textContent.trim());
     const updateTime = (Number.isNaN(updateTimeText)) ? null : new Date(1000 * updateTimeText);
-    const remoteLink = xpathNode(row, "./td[a][1]/a").href;
-    // NOTE: the URL is not encoded here (!)
-    const remoteUrl = remoteLink.slice(remoteLink.indexOf('?') + 1);
     const versionistaUrl = xpathNode(row, "./td[a][2]/a").href;
+
+    // Versionista's link to the live page used to be a redirect like:
+    //   https://versionista.com/viewUrl?{unencoded_destination_URL}
+    // It now appears just be a regular link. Try and handle both cases in case
+    // they switch it up again.
+    let remoteUrl = xpathNode(row, "./td[a][1]/a").href;
+    if (/^(\/|https?:\/\/[^\/]*versionista\.com)/i.test(remoteUrl)) {
+      const queryIndex = remoteUrl.indexOf('?');
+      if (queryIndex === -1) {
+        throw new Error(`Cannot extract original page URL from Versionista redirect: "${remoteUrl}"`);
+      }
+      remoteUrl = remoteUrl.slice(queryIndex + 1);
+    }
 
     // Sanity-check totalVersions
     if (!Number.isNaN(totalVersions) && totalVersions > 10000) {


### PR DESCRIPTION
Versionista's links to the actual, live page being monitored used to go through a redirect. We previously processed that URL and looked for the actual destination URL inside it, which was after the querystring. Now they are simple direct links. For URLs without querystrings, this continued to function fine, but for those *with* querystrings, we wound up cutting off everything before the querysting of the destination!

For example, this:

    http://research.noaa.gov/SecureContentAdd/tabid/405/Default.aspx?returnurl=%2FHome%2FPrivacyPolicy.aspx

became:

    returnurl=%2FHome%2FPrivacyPolicy.aspx

…an obviously incorrect and invalid URL.

The new strategy checks to see if the literal URL is within Versionista, in which case we assume it functions like a redirect. Otherwise we just take the URL as-is.