### PR TITLE
Add error tracking with Sentry.io

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -29,3 +29,6 @@ export WEB_MONITORING_EMAIL=zzz@gmail.com
 export WEB_MONITORING_PASSWORD=XYZ
 # NOTE: no need to specify this if at the default URL as below
 export WEB_MONITORING_URL=https://api.monitoring.envirodatagov.org/
+
+# Uncomment and fill in to track errors with Sentry.io
+# export SENTRY_DSN=https://xyz@sentry.io/abc

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
+const sentryErrors = require('../lib/sentry-errors').setup();
+
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
@@ -105,6 +107,11 @@ function importJsonFile (filePath, callback) {
       if (errors.length) {
         exitCode = 1;
         errors.forEach(error => console.error(error));
+        // sentryErrors.captureMessage(`${errors.length} import errors: ${errors.join(', ')}`);
+        sentryErrors.captureMessage(
+          `${errors.length} import errors`,
+          {extra: {errors: errors}}
+        );
       }
 
       console.log(`Completed ${versionsTotal} versions.`);
@@ -124,8 +131,8 @@ function complete (error) {
   }
 
   console.error(`Completed in ${(Date.now() - startDate) / 1000} seconds.`);
-  console.error(`  ${versionsImported} of ${versionsTotal} imported from ${filesTotal} files.`)
-  process.exit(exitCode);
+  console.error(`  ${versionsImported} of ${versionsTotal} imported from ${filesTotal} files.`);
+  sentryErrors.flush().then(() => process.exit(exitCode));
 }
 
 function processNextFile () {

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 'use strict';
 
+// Set up Sentry.io error tracking
+const Raven = require('raven');
+if (process.env['SENTRY_DSN']) {
+  Raven.config(process.env['SENTRY_DSN'], {
+    captureUnhandledRejections: true
+  }).install();
+}
+
 const path = require('path');
 const stream = require('stream');
 const fs = require('fs-promise');
@@ -135,6 +143,8 @@ function writeFile (name, content, encoding = 'utf8') {
 
 let errorStream;
 let errorCount = 0;
+let errorsInFlight = 0;
+let errorsComplete = () => null;
 function logError (error) {
   errorCount++;
 
@@ -149,12 +159,34 @@ function logError (error) {
 
   errorStream.write(error.stack || error.message || error.toString());
   errorStream.write('\n');
+
+  errorsInFlight++;
+  Raven.captureException(error, () => {
+    errorsInFlight--;
+    if (errorsInFlight === 0) {
+      errorsComplete();
+    }
+  });
 }
 
 function flushErrors () {
-  if (errorStream && errorStream !== process.stderr) {
-    errorStream.end();
-  }
+  return new Promise((resolve, reject) => {
+    if (errorStream && errorStream !== process.stderr) {
+      errorStream.end();
+    }
+
+    // Ensure any errors sent to Sentry.io have the opportunity to get there!
+    if (errorsInFlight) {
+      const timer = setTimeout(() => resolve(), 5000);
+      errorsComplete = () => {
+        resolve();
+        clearTimeout(timer);
+      };
+    }
+    else {
+      resolve();
+    }
+  });
 }
 
 function minimum (items, getValue = Number) {
@@ -525,7 +557,13 @@ files
     console.error(`Completed in ${seconds} seconds`);
     if (errorCount) {
       console.error(`  with ${errorCount} errors`);
+      return new Promise(resolve => {
+        Raven.captureMessage(
+          `Completed in ${seconds} seconds with  ${errorCount} errors`,
+          () => resolve()
+        )
+      });
     }
-    flushErrors();
-    process.exit(errorCount ? 1 : 0);
-  });
+  })
+  .then(() => flushErrors())
+  .then(() => process.exit(errorCount ? 1 : 0));

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -1,13 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-// Set up Sentry.io error tracking
-const Raven = require('raven');
-if (process.env['SENTRY_DSN']) {
-  Raven.config(process.env['SENTRY_DSN'], {
-    captureUnhandledRejections: true
-  }).install();
-}
+const sentryErrors = require('../lib/sentry-errors').setup();
 
 const path = require('path');
 const stream = require('stream');
@@ -143,8 +137,6 @@ function writeFile (name, content, encoding = 'utf8') {
 
 let errorStream;
 let errorCount = 0;
-let errorsInFlight = 0;
-let errorsComplete = () => null;
 function logError (error) {
   errorCount++;
 
@@ -159,34 +151,15 @@ function logError (error) {
 
   errorStream.write(error.stack || error.message || error.toString());
   errorStream.write('\n');
-
-  errorsInFlight++;
-  Raven.captureException(error, () => {
-    errorsInFlight--;
-    if (errorsInFlight === 0) {
-      errorsComplete();
-    }
-  });
+  sentryErrors.captureException(error);
 }
 
 function flushErrors () {
-  return new Promise((resolve, reject) => {
-    if (errorStream && errorStream !== process.stderr) {
-      errorStream.end();
-    }
+  if (errorStream && errorStream !== process.stderr) {
+    errorStream.end();
+  }
 
-    // Ensure any errors sent to Sentry.io have the opportunity to get there!
-    if (errorsInFlight) {
-      const timer = setTimeout(() => resolve(), 5000);
-      errorsComplete = () => {
-        resolve();
-        clearTimeout(timer);
-      };
-    }
-    else {
-      resolve();
-    }
-  });
+  return sentryErrors.flush();
 }
 
 function minimum (items, getValue = Number) {
@@ -557,12 +530,9 @@ files
     console.error(`Completed in ${seconds} seconds`);
     if (errorCount) {
       console.error(`  with ${errorCount} errors`);
-      return new Promise(resolve => {
-        Raven.captureMessage(
-          `Completed in ${seconds} seconds with  ${errorCount} errors`,
-          () => resolve()
-        )
-      });
+      return sentryErrors.captureMessage(
+        `Completed in ${seconds} seconds with  ${errorCount} errors`
+      );
     }
   })
   .then(() => flushErrors())

--- a/bin/scrape-versionista-and-upload
+++ b/bin/scrape-versionista-and-upload
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
+const sentryErrors = require('../lib/sentry-errors').setup();
+
 const path = require('path');
 const spawn = require('child_process').spawn;
 const mkdirp = require('mkdirp');
@@ -10,23 +12,23 @@ const args = neodoc.run(`
 Usage: scrape-versionista-and-upload [options] --output DIRECTORY
 
 Options:
-  -h, --help            Print this lovely help message.
-  --after HOURS         Only include versions from N hours ago. [default: 1]
-  --before HOURS        Only include versions before N hours ago. [default: 0]
-  --output DIRECTORY    Write output to this directory.
-  --email STRING        Versionista account e-mail address [env: VERSIONISTA_EMAIL]
-  --password STRING     Versionista account password [env: VERSIONISTA_PASSWORD]
-  --account-name NAME   Name to use for Versionista account in output. [env: VERSIONISTA_NAME]
-  --s3-key KEY          S3 access key [env: AWS_S3_KEY]
-  --s3-secret SECRET    S3 secret key [env: AWS_S3_SECRET]
-  --s3-bucket NAME      S3 bucket to upload to [env: AWS_S3_BUCKET]
-  --google-project ID   Google Cloud project ID [env: GOOGLE_PROJECT_ID]
-  --google-key PATH     Google Cloud key file [env: GOOGLE_STORAGE_KEY_FILE]
-  --google-bucket NAME  Google Could bucket to upload to [env: GOOGLE_BUCKET]
-  --throughput NUM      Number of simultaneous uploads to allow
-  --db-email STRING     Login e-mail for web-monitoring-db [env: WEB_MONITORING_EMAIL]
-  --db-password STRING  Password for web-monitoring-db [env: WEB_MONITORING_PASSWORD]
-  --db-url STRING       URL for web-monitoring-db instance [env: WEB_MONITORING_URL]
+  -h, --help                Print this lovely help message.
+  --after HOURS             Only include versions from N hours ago. [default: 1]
+  --before HOURS            Only include versions before N hours ago. [default: 0]
+  --output DIRECTORY        Write output to this directory.
+  --email STRING            Versionista account e-mail address [env: VERSIONISTA_EMAIL]
+  --password STRING         Versionista account password [env: VERSIONISTA_PASSWORD]
+  --account-name NAME       Name to use for Versionista account in output. [env: VERSIONISTA_NAME]
+  --s3-key KEY              S3 access key [env: AWS_S3_KEY]
+  --s3-secret SECRET        S3 secret key [env: AWS_S3_SECRET]
+  --s3-bucket NAME          S3 bucket to upload to [env: AWS_S3_BUCKET]
+  --google-project ID       Google Cloud project ID [env: GOOGLE_PROJECT_ID]
+  --google-key PATH         Google Cloud key file [env: GOOGLE_STORAGE_KEY_FILE]
+  --google-bucket NAME      Google Could bucket to upload to [env: GOOGLE_BUCKET]
+  --throughput NUM          Number of simultaneous uploads to allow
+  --db-email STRING         Login e-mail for web-monitoring-db [env: WEB_MONITORING_EMAIL]
+  --db-password STRING      Password for web-monitoring-db [env: WEB_MONITORING_PASSWORD]
+  --db-url STRING           URL for web-monitoring-db instance [env: WEB_MONITORING_URL]
   --scrape-parallel NUM     Number of parallel connections to Versionista allowed.
   --scrape-pause-every NUM  Pause briefly after this many requests to Versionista.
   --scrape-pause-time MS    Milliseconds to pause for (see --scrape-pause-every)
@@ -49,7 +51,8 @@ const dbUrls = (args['--db-url'] || '')
 archiveAndUpload(args['--email'], args['--password'], error => {
   if (error) {
     console.error(error);
-    process.exit(1);
+    sentryErrors.captureMessage(`scrape-versionista-and-upload: ${error}`)
+      .then(() => process.exit(1));
   }
   else {
     console.error('Archive and upload complete!');

--- a/bin/upload-to-google
+++ b/bin/upload-to-google
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
+const sentryErrors = require('../lib/sentry-errors').setup();
+
 const path = require('path');
 const stream = require('stream');
 const fs = require('fs');
@@ -66,11 +68,12 @@ pump(
   deferStreamItems(file => path.basename(file.path).startsWith('metadata-')),
   parallel(throughput, retryable(uploadFile)),
   error => {
+    console.error(`Completed in ${(Date.now() - startDate) / 1000} seconds.`);
+
     if (error) {
       console.error(error);
+      sentryErrors.captureException(error).then(() => process.exit(1));
     }
-
-    console.error(`Completed in ${(Date.now() - startDate) / 1000} seconds.`);
   });
 
 

--- a/bin/upload-to-s3
+++ b/bin/upload-to-s3
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict';
 
+const sentryErrors = require('../lib/sentry-errors').setup();
+
 const path = require('path');
 const stream = require('stream');
 const fs = require('fs');
@@ -59,11 +61,12 @@ pump(
   deferStreamItems(file => path.basename(file.path).startsWith('metadata-')),
   parallel(throughput, retryable(uploadFile)),
   error => {
+    console.error(`Completed in ${(Date.now() - startDate) / 1000} seconds.`);
+
     if (error) {
       console.error(error);
+      sentryErrors.captureException(error).then(() => process.exit(1));
     }
-
-    console.error(`Completed in ${(Date.now() - startDate) / 1000} seconds.`);
   });
 
 

--- a/lib/sentry-errors.js
+++ b/lib/sentry-errors.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * A simplified interface to Sentry.io's Raven library that makes it easy to
+ * wait until calls to Sentry.io are complete.
+ */
+
+const EventEmitter = require('events');
+const Raven = require('raven');
+
+const defaultOptions = {captureUnhandledRejections: true};
+const maximumWaitTime = 5000;
+
+const asyncTracker = Object.assign(new EventEmitter(), {
+  active: 0,
+
+  trackMethod (context, functionName) {
+    return (...args) => {
+      return new Promise(resolve => {
+        this.active++;
+        context[functionName](...args, () => {
+          this.active--;
+          if (this.active === 0) {
+            this.emit('allMessagesEnded');
+          }
+          resolve();
+        });
+      });
+    };
+  },
+
+  waitUntilInactive () {
+    return new Promise(resolve => {
+      if (this.active === 0) {
+        return resolve();
+      }
+
+      const timer = setTimeout(listener, maximumWaitTime);
+      this.on('allMessagesEnded', listener);
+      function listener () {
+        this.removeListener('allMessagesEnded', listener);
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+  }
+});
+
+exports.setup = function (options, dsn = process.env['SENTRY_DSN']) {
+  if (dsn) {
+    Raven.config(dsn, Object.assign({}, defaultOptions, options)).install();
+  }
+  return exports;
+}
+
+exports.captureException = asyncTracker.trackMethod(Raven, 'captureException');
+exports.captureMessage = asyncTracker.trackMethod(Raven, 'captureMessage');
+exports.flush = () => asyncTracker.waitUntilInactive();
+exports.Raven = Raven;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "nodemailer": "^4.0.1",
     "parallel-transform": "^1.1.0",
     "pump": "^1.0.2",
+    "raven": "^2.4.2",
     "request": "^2.81.0",
     "split": "^1.0.0",
     "unzip-stream": "^0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -253,6 +253,10 @@ chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -296,6 +300,10 @@ content-type-parser@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
 
+cookie@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -305,6 +313,10 @@ create-error-class@^3.0.2:
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
   dependencies:
     capture-stack-trace "^1.0.0"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -654,6 +666,10 @@ inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
+is-buffer@~1.1.1:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
 is-my-json-valid@^2.12.4:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz#f079dd9bfdae65ee2038aae8acbc86ab109e3693"
@@ -807,6 +823,14 @@ lodash@^4.0.0, lodash@^4.14.0:
 log-driver@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
+
+md5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 methmeth@^1.1.0:
   version "1.1.0"
@@ -998,6 +1022,16 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
 
+raven@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/raven/-/raven-2.4.2.tgz#0129e2adc30788646fd530b67d08a8ce25d4f6dc"
+  dependencies:
+    cookie "0.3.1"
+    md5 "^2.2.1"
+    stack-trace "0.0.9"
+    timed-out "4.0.1"
+    uuid "3.0.0"
+
 readable-stream@^2.0.0, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.2.9"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.9.tgz#cf78ec6f4a6d1eb43d26488cac97f042e74b7fc8"
@@ -1134,6 +1168,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+stack-trace@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.9.tgz#a8f6eaeca90674c333e7c43953f275b451510695"
+
 stream-events@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stream-events/-/stream-events-1.0.1.tgz#4fe7b2bbfcc53e6af31087e8c540483f412ce8c6"
@@ -1199,6 +1237,10 @@ through@2:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
+timed-out@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
 tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
@@ -1260,6 +1302,10 @@ url@0.10.3:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+uuid@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.0.tgz#6728fc0459c450d796a99c31837569bdf672d728"
 
 uuid@3.0.1, uuid@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
I should have done this looooooooong ago, but I’ve been lazy. Adds Sentry to all the scripts we run on a regular schedule:

- `scrape-versionista` (already done in a previous commit)
- `upload-to-s3` (also fixes an issue where this script fails to exit with an error code when it has an error!)
- `upload-to-google` (also fixes an issue where this script fails to exit with an error code when it has an error!)
- `import-to-db` (with some very fancy logging of the actual row-by-row error messages)
- `scrape-versionista-and-upload` (the script that ties all these together)

Other scripts are always run manually, so we don't really need special automated error tracking for them.

To get error tracking going, set the `SENTRY_DSN` environment variable based on your Sentry.io account.