### PR TITLE
HOTFIX: Failure on table redesign in Versionista

### DIFF
--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -376,6 +376,12 @@ let versions = pages
 
       const pageVersions = scraper.getVersions(page.versionistaUrl)
         // Log errors, but do not fail if no date could be found for a version.
+        .then(versions => {
+          if (versions.length === 0) {
+            console.warn(`No versions found for ${page.versionistaUrl}`);
+          }
+          return versions;
+        })
         .then(versions => versions.filter(version => {
           if (!version.date) {
             logError(`No date found for version: ${JSON.stringify(version)}`);

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -200,17 +200,20 @@ class Versionista {
    */
   getVersions (pageUrl) {
     const versionDataForRow = (versionRow) => {
-      const dateNode = xpathNode(versionRow, "./td[2]//*[@class='gmt']");
       const linkNode = xpathNode(versionRow, "./td[2]/a");
-      const timestamp = 1000 * parseFloat(dateNode.textContent);
-      const date = Number.isNaN(timestamp) ? null : new Date(timestamp);
-
       let url = linkNode && linkNode.href;
-      let hasContent = !!url;
+      const hasContent = !!url;
       if (!url) {
         const versionId = versionRow.id.match(/^version_([^_]+)/)[1];
         url = joinUrlPaths(pageUrl, versionId);
       }
+
+      const dateNode = xpathNode(versionRow, "./td[2]//*[@class='gmt']");
+      if (!dateNode) {
+        throw new Error(`Could not find date field for version "${url}"`);
+      }
+      const timestamp = 1000 * parseFloat(dateNode.textContent);
+      const date = Number.isNaN(timestamp) ? null : new Date(timestamp);
 
       let errorCode;
       const errorCodeNotices = versionRow.querySelectorAll('.failpage');
@@ -234,7 +237,8 @@ class Versionista {
     }
 
     return this.request(pageUrl).then(window => {
-      const versionRows = xpathArray(window.document, "//*[@id='pageTableBody']/tr");
+      const versionRows = Array.from(window.document.querySelectorAll(
+        '#pageTableBody > tr.version'));
       let oldestVersion;
       let previousVersion;
       let oldestSafeVersion;
@@ -267,8 +271,6 @@ class Versionista {
 
         return version;
       });
-
-      return
     });
   }
 


### PR DESCRIPTION
Versionista redesigned the table layout on the page history view (`https://versionista.com/{site}/{page}/`) so that every other row is a hidden form pertaining to the version in the row above it. We were tripping over these non-version rows. This change uses a class that was added to the version rows in order to identify and scan *just* them. It also gets a little stricter on handling the situation so similar issues are more obvious in the future:
- If we don't find any version rows, we print a warning.
- If we don't find a node representing the date in a row, we throw a more descriptive error (previously we just got "can't read property `textContent` of `undefined`").

**I’ve already deployed a much more minimal version of this fix to the scraper** and run a job to recover the last several hours since Versionista redesigned (just before midnight pacific time). I’ll still probably merge this pretty quickly later today unless someone sees something really problematic, though.