### PR TITLE
Remove unused html-entities dependency

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -2,7 +2,6 @@
 
 const crypto = require('crypto');
 const stream = require('stream');
-const Entities = require('html-entities').AllHtmlEntities;
 const jsdom = require('jsdom');
 const mime = require('mime-types');
 const unzip = require('unzip-stream');

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "aws-sdk": "^2.257.1",
     "fast-crc32c": "^1.0.4",
     "fs-promise": "^2.0.0",
-    "html-entities": "^1.2.0",
     "jsdom": "^9.12.0",
     "klaw": "^2.1.1",
     "mime-types": "^2.1.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -631,10 +631,6 @@ html-encoding-sniffer@^1.0.1:
   dependencies:
     whatwg-encoding "^1.0.1"
 
-html-entities@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-1.2.0.tgz#41948caf85ce82fed36e4e6a0ed371a6664379e2"
-
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"


### PR DESCRIPTION
We stopped using this in #48 when the raw content downloading system changed to stop using ZIP archives.