### PR TITLE
HOTFIX: Handle missing links to original page when Versionista received an error while scanning

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -631,22 +631,29 @@ function getPageDetailData (window) {
         // Versionista no longer gives us a link to the original content if the
         // last scan failed. Now we try and piece it together from the site URL
         // at the top of the page and the path listed as text in this row.
-        const remoteBaseUrlNode = window.document.querySelector('a.sstA');
-        if (remoteBaseUrlNode && remoteBaseUrlNode.href.startsWith('http')) {
-          const remoteBaseUrl = remoteBaseUrlNode.href.replace(/\/$/, '');
-          const remotePath = xpathNode(row, "./td[4]/a").textContent.trim();
-          if (remotePath.startsWith('/')) {
-            remoteUrl = remoteBaseUrl + remotePath;
-          }
-          else if (/^(http|https|ftp):/.test(remotePath)) {
-            remoteUrl = remotePath;
-          }
-          else {
-            throw new Error(`Cannot extract original page URL by combining page parts: "${remoteUrl}" / baseUrl: "${remoteBaseUrl}" path: "${remotePath}"`);
-          }
+        const remotePathNode = xpathNode(row, "./td[4]/a");
+        if (!remotePathNode) {
+          throw new Error(`Cannot find this page's URL path in its site: "${remoteUrl}"`);
         }
+        const remotePath = remotePathNode.textContent.trim();
+
+        // Sometimes it's actually a full URL, in which case we are good to go.
+        if (/^(http|https|ftp):/.test(remotePath)) {
+          remoteUrl = remotePath;
+        }
+        // But usually it's a path, so we have to go find the base URL.
+        else if (remotePath.startsWith('/')) {
+          // NOTE: I suspect this selector is pretty prone to failure.
+          const remoteBaseUrlNode = window.document.querySelector('a.sstA');
+          if (!remoteBaseUrlNode || !remoteBaseUrlNode.href.startsWith('http')) {
+            throw new Error(`Can't find base URL of web site to use with URL path: "${remotePath}" (Versionista: "${remoteUrl}")`);
+          }
+          const remoteBaseUrl = remoteBaseUrlNode.href.replace(/\/$/, '');
+          remoteUrl = remoteBaseUrl + remotePath;
+        }
+        // Otherwise, who knows!
         else {
-          throw new Error(`Cannot extract original page URL from Versionista redirect: "${remoteUrl}"`);
+          throw new Error(`The URL path for this page doesn't seem to be valid: "${remotePath}" (Versionista: ${remoteUrl})`);
         }
       }
       remoteUrl = remoteUrl.slice(queryIndex + 1);

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -628,7 +628,23 @@ function getPageDetailData (window) {
     if (/^(\/|https?:\/\/[^\/]*versionista\.com)/i.test(remoteUrl)) {
       const queryIndex = remoteUrl.indexOf('?');
       if (queryIndex === -1) {
-        throw new Error(`Cannot extract original page URL from Versionista redirect: "${remoteUrl}"`);
+        // Versionista no longer gives us a link to the original content if the
+        // last scan failed. Now we try and piece it together from the site URL
+        // at the top of the page and the path listed as text in this row.
+        const remoteBaseUrlNode = window.document.querySelector('a.sstA');
+        if (remoteBaseUrlNode && remoteBaseUrlNode.href.startsWith('http')) {
+          const remoteBaseUrl = remoteBaseUrlNode.href.replace(/\/$/, '');
+          const remotePath = xpathNode(row, "./td[4]/a").textContent.trim();
+          if (remotePath.startsWith('/')) {
+            remoteUrl = remoteBaseUrl + remotePath;
+          }
+          else {
+            throw new Error(`Cannot extract original page URL by combining page parts: "${remoteUrl}" / baseUrl: "${remoteBaseUrl}"`);
+          }
+        }
+        else {
+          throw new Error(`Cannot extract original page URL from Versionista redirect: "${remoteUrl}"`);
+        }
       }
       remoteUrl = remoteUrl.slice(queryIndex + 1);
     }

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -638,11 +638,11 @@ function getPageDetailData (window) {
           if (remotePath.startsWith('/')) {
             remoteUrl = remoteBaseUrl + remotePath;
           }
-          else if (/^http(s?):/.test(remotePath)) {
+          else if (/^(http|https|ftp):/.test(remotePath)) {
             remoteUrl = remotePath;
           }
           else {
-            throw new Error(`Cannot extract original page URL by combining page parts: "${remoteUrl}" / baseUrl: "${remoteBaseUrl}"`);
+            throw new Error(`Cannot extract original page URL by combining page parts: "${remoteUrl}" / baseUrl: "${remoteBaseUrl}" path: "${remotePath}"`);
           }
         }
         else {

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -638,6 +638,9 @@ function getPageDetailData (window) {
           if (remotePath.startsWith('/')) {
             remoteUrl = remoteBaseUrl + remotePath;
           }
+          else if (/^http(s?):/.test(remotePath)) {
+            remoteUrl = remotePath;
+          }
           else {
             throw new Error(`Cannot extract original page URL by combining page parts: "${remoteUrl}" / baseUrl: "${remoteBaseUrl}"`);
           }


### PR DESCRIPTION
Versionista removed the link to the original URL (e.g. to `https://www.nesdis.noaa.gov/star/EPL_PeerReviewGuidelines.php`) on pages where the latest version was an error (e.g. a 404 not found or a 403 forbidden or a 500 server error). This tries and work around that by composing the URL from various bits of information across the listing page.