### PR TITLE
HOTFIX: handle pages with no versions

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -234,6 +234,11 @@ function getSiteUpdates () {
 
         const latest = page.versions[0];
         page.latest = latest;
+        if (!latest) {
+          // Don't add a page to the list if it has no versions.
+          console.warn(`Found page with no versions: ${page.uuid}`);
+          return;
+        }
 
         // Check whether there was also a non-error version that we should show
         if (isError(latest)) {


### PR DESCRIPTION
This has always been a possibility in the API, but I guess I failed to handle it before. A recent error in Versionista appears to have caused us to create some pages without corresponding versions :\