### PR TITLE
HOTFIX: Remote base URL selector no longer working

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -644,7 +644,8 @@ function getPageDetailData (window) {
         // But usually it's a path, so we have to go find the base URL.
         else if (remotePath.startsWith('/')) {
           // NOTE: I suspect this selector is pretty prone to failure.
-          const remoteBaseUrlNode = window.document.querySelector('a.sstA');
+          const remoteBaseUrlNode = window.document.querySelector(
+            '#siteOptions a[title*="live site"]');
           if (!remoteBaseUrlNode || !remoteBaseUrlNode.href.startsWith('http')) {
             throw new Error(`Can't find base URL of web site to use with URL path: "${remotePath}" (Versionista: "${remoteUrl}")`);
           }


### PR DESCRIPTION
The selector `.sstA` doesn't seem to work reliably anymore to find the “base” URL of a remote site (e.g. `https://earthdata.nasa.gov`). That's not a *huge* surprise -- it's not totally clear to me what that is abbreviating, so it didn't ever seem like a fully stable name. It *looks* like what's happening is that, if the last scan of a page in the site was an error, the class switches to `.sstF` (`F` for failure?). In lieu of just selecting both of those, I switched to a a slightly more broad selector that uses the "view live site" text in the `title` attribute. We'll see how long that lasts (seems iffy since that's human-readable text that could change when the structure does not).