### PR TITLE
Auto-retry Versionista requests if they time out

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -80,6 +80,7 @@ function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepE
         sleepIfNecessary();
 
         const shouldRetry = (error && error.code === 'ECONNRESET')
+          || (error && error.code === 'ETIMEDOUT')
           || (response && task.retryIf(response));
 
         if (shouldRetry && task.retries < MAX_RETRIES) {
@@ -88,7 +89,16 @@ function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepE
           sleep(sleepFor * task.retries * 2);
         }
         else if (error) {
-          task.reject(error);
+          let message = error.message;
+          try {
+            message += ` with options ${JSON.stringify(task.options)}`
+          }
+          catch (jsonError) {
+            message += ' with unserializable options';
+          }
+          const customError = new Error(message);
+          customError.code = error.code;
+          task.reject(customError);
         }
         else {
           task.resolve(response);


### PR DESCRIPTION
We previously only auto-retried on connection resets, but timeouts have turned out to be a common situation where we should be doing this too.

Also add improved error messaging with information about the request options that were used.

This code has been running on the server without incident for a few weeks.