### PR TITLE
Choose only one site’s CSV to include a page in

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -225,12 +225,10 @@ function getSiteUpdates () {
     // Group pages by site
     .then(pages => {
       pages.forEach(page => {
-        page.sites = page.tags
+        page.site = page.tags
           .filter(tag => tag.name.startsWith('site:'))
-          .map(tag => tag.name.replace(/^site:/, ''));
-        if (page.sites.length === 0) {
-          page.sites = ['no site'];
-        }
+          .map(tag => tag.name.replace(/^site:/, ''))
+          .sort()[0] || 'no site';
 
         const latest = page.versions[0];
         page.latest = latest;
@@ -248,13 +246,13 @@ function getSiteUpdates () {
             const version = page.versions[i];
             if (!isError(version)) {
               const nonErrorPage = Object.assign({}, page, {latest: version});
-              page.sites.forEach(site => pagesBySite.add(site, nonErrorPage));
+              pagesBySite.add(page.site, nonErrorPage);
               break;
             }
           }
         }
         else {
-          page.sites.forEach(site => pagesBySite.add(site, page));
+          pagesBySite.add(page.site, page);
         }
       });
 
@@ -292,7 +290,7 @@ function csvStringForPages (pages) {
         // TODO: format
         timeString,
         page.maintainers.map(maintainer => maintainer.name).join(', '),
-        page.sites.join(', '),
+        page.site,
         page.title,
         page.url,
         // for now, the "page view" link is always to Versionista


### PR DESCRIPTION
In the `query-db-and-email` script, only include a page in one CSV (instead of every CSV for a site that it's in). Choose the CSV/site to use for a page by taking the first one alphabetically. Fixes #130.