### PR TITLE
Auto-retry requests for more types of errors

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,18 @@ const SLEEP_FOR = 1000;
 const MAX_RETRIES = 3;
 const MAX_PER_MINUTE = 0;
 
+// LibUV error codes we should attempt to resolve by retrying.
+// List of all codes: https://github.com/nodejs/node/blob/8174d0c8cae857296c45b2c448348f2c781f6ace/deps/uv/include/uv.h#L66-L145
+const RETRYABLE_ERRORS = [
+  'EAI_AGAIN',     // temporary failure
+  'EAI_MEMORY',    // out of memory
+  'EAI_NONAME',    // unknown node or service
+  'EBUSY',         // resource busy or locked
+  'ECONNREFUSED',  // connection refused
+  'ECONNRESET',    // connection reset by peer
+  'ETIMEDOUT'      // connection timed out
+];
+
 function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepEvery = SLEEP_EVERY, sleepFor = SLEEP_FOR, maxPerMinute = MAX_PER_MINUTE} = {}) {
   maxPerMinute = maxPerMinute || Infinity; // Allow 0 to imply Infinity
 
@@ -79,8 +91,7 @@ function createClient ({userAgent = USER_AGENT, maxSockets = MAX_SOCKETS, sleepE
         availableSockets++;
         sleepIfNecessary();
 
-        const shouldRetry = (error && error.code === 'ECONNRESET')
-          || (error && error.code === 'ETIMEDOUT')
+        const shouldRetry = (error && RETRYABLE_ERRORS.includes(error.code))
           || (response && task.retryIf(response));
 
         if (shouldRetry && task.retries < MAX_RETRIES) {


### PR DESCRIPTION
In production, we were seeing `EAI_AGAIN` (“temporary failure,” specifically in DNS resolution) errors that could potentially have been resolved by retrying the request. Instead of *just* adding that, I took a look at the error codes libuv might spit out and attempted to pick a better list of ones that might make sense to retry on. It's likely not perfect, but should be a good reliability improvement.

Source of these codes is the Node.js/libuv header: 
https://github.com/nodejs/node/blob/8174d0c8cae857296c45b2c448348f2c781f6ace/deps/uv/include/uv.h#L66-L145

Fixes #129.

@b5, can I ask you to take a gander and see if this list seems sane?