### PR TITLE
Indicate source type in e-mail subject and body

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -332,7 +332,8 @@ function sendResults (result) {
       from: `"${senderEmailName}" <${args['--sender-email']}>`,
       to: args['--receiver-email']
     };
-    const subjectDetails = `All Versionista Accounts @ ${friendlyDate}`
+    const sourceName = sourceType || 'all';
+    const subjectDetails = `${sourceName} versions @ ${friendlyDate}`
     let signature = randomItem([
       '- Your friendly scraperbot',
       '- Your friendly scraperbot',
@@ -351,7 +352,7 @@ function sendResults (result) {
         '💩!'
       ]);
 
-      message.text = `${greeting}\n\nThere was an error scraping the last ${args['--after']} hours of Versionista versions out of our DB at ${friendlyTime}:\n\n${result.rawText || result.message}\n\n${result.stack}\n${signature}`;
+      message.text = `${greeting}\n\nThere was an error scraping the last ${args['--after']} hours of ${sourceName} versions out of our DB at ${friendlyTime}:\n\n${result.rawText || result.message}\n\n${result.stack}\n${signature}`;
     }
     else {
       message.subject = `[Experimental DB Query] Scraped ${subjectDetails}`;
@@ -370,7 +371,7 @@ function sendResults (result) {
       ]);
 
       const linkDestination = linkToVersionista ? 'Versionista' : 'the Web Monitoring UI';
-      message.text = `${greeting}\n\nI scraped the last ${args['--after']} hours of Versionista versions out of our DB at ${friendlyTime}.\nThe links in this data point to ${linkDestination}.\n\n${result.text}${signature}`;
+      message.text = `${greeting}\n\nI scraped the last ${args['--after']} hours of ${sourceName} versions out of our DB at ${friendlyTime}.\nThe links in this data point to ${linkDestination}.\n\n${result.text}${signature}`;
       message.attachments = [{path: result.path}];
     }
 


### PR DESCRIPTION
We have a `--source-type` CLI option, but never actually indicated what it was set to in the e-mail that  gets sent out, which definitely makes things tough to sort through. This adds it to both the subject line and e-mail body.