### PR TITLE
Add priority to analyst sheets

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -1,15 +1,16 @@
 #!/usr/bin/env node
 'use strict';
 
-const path = require('path');
-const spawn = require('child_process').spawn;
+const {compareMany, ascend, descend, getDeep} = require('../lib/tools');
 const flatten = require('../lib/flatten');
+const formatCsv = require('../lib/formatters/csv');
 const fs = require('fs-promise');
 const neodoc = require('neodoc');
 const nodemailer = require('nodemailer');
+const path = require('path');
 const request = require('request');
+const spawn = require('child_process').spawn;
 const stream = require('stream');
-const formatCsv = require('../lib/formatters/csv');
 
 const args = neodoc.run(`
 Query our database for updated pages/versions and send an e-mail with details.
@@ -176,6 +177,10 @@ function getSiteUpdates () {
     source_type: sourceType,
     chunk_size: chunkSize
   })
+  .catch(error => {
+    console.error(`Failed to get all pages: ${error}`);
+    return Promise.reject(error);
+  });
 
   // Looking up all the versions in one shot is much more efficient than
   // looking up the versions for each page individually
@@ -186,6 +191,10 @@ function getSiteUpdates () {
     sort: 'capture_time:desc',
     include_change_from_previous: true
   })
+  .catch(error => {
+    console.error(`Failed to get all versions: ${error}`);
+    return Promise.reject(error);
+  });
 
   return Promise.all([timeframePages, timeframeVersions])
     .then(([pages, versions]) => {
@@ -280,80 +289,91 @@ function writeCsvsForSites (pagesBySite) {
   }));
 }
 
-function csvStringForPages (pages) {
-  const rows = pages
-    .map(page => {
-      const earliest = page.earliest || {uuid: '', metadata: {}};
-      const version = page.latest || {uuid: '', metadata: {}};
-      const metadata = version.source_metadata;
-      const changePrevious = version.change_from_previous;
-      const annotationPrevious = changePrevious && changePrevious.current_annotation || {};
+// Create an object representing an annotation, whether one was present or not
+function compileAnnotation (version) {
+  const meta = version.source_metadata || {};
+  return Object.assign({
+    source_diff_length: meta.diff_length || 0,
+    source_diff_hash: meta.diff_hash || '?',
+    text_diff_length: meta.text_diff_length || 0,
+    text_diff_hash: meta.text_diff_hash || '?'
+  }, getDeep(version, 'change_from_previous', 'current_annotation'));
+}
 
-      return [
-        '',
-        version.uuid,
-        // TODO: format
-        timeString,
-        page.maintainers.map(maintainer => maintainer.name).join(', '),
-        page.site,
-        page.title,
-        page.url,
-        // for now, the "page view" link is always to Versionista
-        createViewUrl(page, null, null, true),
-        createViewUrl(page, version),
-        createViewUrl(page, version, earliest),
-        formatCsv.formatDate(new Date(version.capture_time)),
-        earliest.capture_time ? formatCsv.formatDate(new Date(earliest.capture_time)) : '----',
-        annotationPrevious.source_diff_length || metadata.diff_length || 0,
-        annotationPrevious.source_diff_hash || metadata.diff_hash,
-        annotationPrevious.text_diff_length || metadata.diff_text_length || 0,
-        annotationPrevious.text_diff_hash || metadata.diff_text_hash,
-        annotationPrevious.priority
-      ];
-    })
+function csvStringForPages (pages) {
+  const blankVersion = {uuid: '', source_metadata: {}};
+  const entries = pages
+    .map(page => {
+      const earliest = page.earliest || blankVersion;
+      const version = page.latest || blankVersion;
+      earliest.capture_time = parseDate(earliest.capture_time);
+      version.capture_time = parseDate(version.capture_time);
+      const annotation = compileAnnotation(version);
+      return {page, earliest, version, annotation};
+    });
+
+  // Creates a CSV row from an entry object (above)
+  const createRow = ({page, earliest, version, annotation}, index) => {
+    return [
+      index + 1,
+      version.uuid,
+      // TODO: format
+      timeString,
+      page.maintainers.map(maintainer => maintainer.name).join(', '),
+      page.site,
+      page.title,
+      page.url,
+      // for now, the "page view" link is always to Versionista
+      createViewUrl(page, null, null, true),
+      createViewUrl(page, version),
+      createViewUrl(page, version, earliest),
+      formatCsv.formatDate(version.capture_time),
+      formatCsv.formatDate(earliest.capture_time) || '----',
+      annotation.source_diff_length,
+      formatHash(annotation.source_diff_hash),
+      annotation.text_diff_length,
+      formatHash(annotation.text_diff_hash),
+      annotation.priority
+    ];
+  };
 
   // Group rows by text hash and sort those groups by their maximum priority.
   // Basically we want something like a priority sort, but we want to make sure
   // identical hashes stay together.
-  const textHashGroups = rows.reduce((grouped, row) => {
-    let group = grouped[row[15]]
+  const textHashGroups = new Map();
+  entries.forEach(entry => {
+    let group = textHashGroups.get(entry.annotation.text_diff_hash);
     if (!group) {
-      group = grouped[row[15]] = {rows: [], priority: 0};
+      group = [];
+      textHashGroups.set(entry.annotation.text_diff_hash, group);
     }
-    group.rows.push(row);
-    group.priority = Math.max(row[16], group.priority);
-    return grouped;
-  }, {});
-  const sortedGroups = Object.values(textHashGroups)
-    .sort((a, b) => b.priority - a.priority)
-    .map(group => group.rows.sort(compareRows));
-  const sortedRows = flatten(sortedGroups);
+    group.push(entry);
+    group.priority = Math.max(group.priority || 0, entry.annotation.priority || 0);
+  });
+
+  const sortedGroups = Array.from(textHashGroups.values())
+    .sort(descend('priority'))
+    .map(group => group.sort(compareMany(
+      ascend(x => x.annotation.source_diff_hash),
+      descend(x => x.annotation.priority),
+      ascend(x => x.version.capture_time)
+    )));
+  const sortedRows = flatten(sortedGroups).map(createRow);
 
   const headers = [...formatCsv.headers, 'priority'];
   return formatCsv.toCsvString([headers, ...sortedRows]);
 }
 
-// Comparator for sorting rows within a text hash group
-function compareRows (a, b) {
-  const a_diff_hash = (a[13] || '').toLowerCase();
-  const b_diff_hash = (b[13] || '').toLowerCase();
+function parseDate (date) {
+  return date && new Date(date);
+}
 
-  if (a_diff_hash === b_diff_hash) {
-    const a_priority = a[16] || 0;
-    const b_priority = b[16] || 0;
+function formatHash (hash) {
+  const isEmpty =
+    hash === 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855' ||  // empty string
+    hash === '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945';    // empty JSON array (`[]`)
 
-    if (a_priority === b_priority) {
-      const a_time = new Date(a[10]);
-      const b_time = new Date(b[10]);
-      if (a_time === b_time) {
-        return 0;
-      }
-      return a_time < b_time ? -1 : 1;
-    }
-    // priority sorts *descending*
-    return a_priority > b_priority ? -1 : 1;
-  }
-  return a_diff_hash < b_diff_hash ? -1 : 1;
+  return isEmpty ? '[no change]' : hash;
 }
 
 function compressPath (targetPath) {
@@ -501,7 +521,7 @@ function getResponse (apiPath, qs) {
 
   return new Promise((resolve, reject) => {
     const url = /^http(s?):\/\//.test(apiPath) ? apiPath : `${dbUrl}${apiPath}`;
-    getWithRetries(url, requestOptions, 2, function (error, response) {
+    getWithRetries(url, requestOptions, 3, function (error, response) {
       if (args['--debug']) {
         console.log(`Got ${url}`);
       }

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -3,6 +3,7 @@
 
 const path = require('path');
 const spawn = require('child_process').spawn;
+const flatten = require('../lib/flatten');
 const fs = require('fs-promise');
 const neodoc = require('neodoc');
 const nodemailer = require('nodemailer');
@@ -182,7 +183,8 @@ function getSiteUpdates () {
     capture_time: `${startTime.toISOString()}..${endTime.toISOString()}`,
     source_type: sourceType,
     chunk_size: chunkSize,
-    sort: 'capture_time:desc'
+    sort: 'capture_time:desc',
+    include_change_from_previous: true
   })
 
   return Promise.all([timeframePages, timeframeVersions])
@@ -284,6 +286,9 @@ function csvStringForPages (pages) {
       const earliest = page.earliest || {uuid: '', metadata: {}};
       const version = page.latest || {uuid: '', metadata: {}};
       const metadata = version.source_metadata;
+      const changePrevious = version.change_from_previous;
+      const annotationPrevious = changePrevious && changePrevious.current_annotation || {};
+
       return [
         '',
         version.uuid,
@@ -299,14 +304,56 @@ function csvStringForPages (pages) {
         createViewUrl(page, version, earliest),
         formatCsv.formatDate(new Date(version.capture_time)),
         earliest.capture_time ? formatCsv.formatDate(new Date(earliest.capture_time)) : '----',
-        metadata.diff_length,
-        metadata.diff_hash,
-        metadata.diff_text_length,
-        metadata.diff_text_hash
+        annotationPrevious.source_diff_length || metadata.diff_length || 0,
+        annotationPrevious.source_diff_hash || metadata.diff_hash,
+        annotationPrevious.text_diff_length || metadata.diff_text_length || 0,
+        annotationPrevious.text_diff_hash || metadata.diff_text_hash,
+        annotationPrevious.priority
       ];
     })
 
-  return formatCsv.toCsvString([formatCsv.headers, ...(formatCsv.sortRows(rows))]);
+  // Group rows by text hash and sort those groups by their maximum priority.
+  // Basically we want something like a priority sort, but we want to make sure
+  // identical hashes stay together.
+  const textHashGroups = rows.reduce((grouped, row) => {
+    let group = grouped[row[15]]
+    if (!group) {
+      group = grouped[row[15]] = {rows: [], priority: 0};
+    }
+    group.rows.push(row);
+    group.priority = Math.max(row[16], group.priority);
+    return grouped;
+  }, {});
+  const sortedGroups = Object.values(textHashGroups)
+    .sort((a, b) => b.priority - a.priority)
+    .map(group => group.rows.sort(compareRows));
+  const sortedRows = flatten(sortedGroups);
+
+  const headers = [...formatCsv.headers, 'priority'];
+  return formatCsv.toCsvString([headers, ...sortedRows]);
+}
+
+// Comparator for sorting rows within a text hash group
+function compareRows (a, b) {
+  const a_diff_hash = (a[13] || '').toLowerCase();
+  const b_diff_hash = (b[13] || '').toLowerCase();
+
+  if (a_diff_hash === b_diff_hash) {
+    const a_priority = a[16] || 0;
+    const b_priority = b[16] || 0;
+
+    if (a_priority === b_priority) {
+      const a_time = new Date(a[10]);
+      const b_time = new Date(b[10]);
+      if (a_time === b_time) {
+        return 0;
+      }
+      return a_time < b_time ? -1 : 1;
+    }
+    // priority sorts *descending*
+    return a_priority > b_priority ? -1 : 1;
+  }
+  return a_diff_hash < b_diff_hash ? -1 : 1;
 }
 
 function compressPath (targetPath) {

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -454,7 +454,7 @@ function getResponse (apiPath, qs) {
 
   return new Promise((resolve, reject) => {
     const url = /^http(s?):\/\//.test(apiPath) ? apiPath : `${dbUrl}${apiPath}`;
-    request.get(url, requestOptions, function(error, response) {
+    getWithRetries(url, requestOptions, 2, function (error, response) {
       if (args['--debug']) {
         console.log(`Got ${url}`);
       }
@@ -477,6 +477,29 @@ function getResponse (apiPath, qs) {
       resolve(body);
     });
   });
+}
+
+// TODO: clean this up?
+function getWithRetries(url, options, retries, callback) {
+  if (typeof retries === 'function') {
+    [callback, retries] = [retries, 2];
+  }
+  let retryCount = 0;
+
+  function handleResult (error, response) {
+    if ((error || response.status >= 500) && retryCount <= retries) {
+      const delay = retryCount > 0 ? 1000 * Math.pow(2, retryCount - 1) : 0
+      setTimeout(() => {
+        retryCount++;
+        request.get(url, options, handleResult);
+      }, delay);
+    }
+    else {
+      callback(error, response);
+    }
+  }
+
+  request.get(url, options, handleResult);
 }
 
 function delayPromise (timeout) {

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const crypto = require('crypto');
 require('../polyfill');
+const {compareMany, ascend} = require('../tools');
+const crypto = require('crypto');
 // TODO: UUID assignment should happen independently of formatting
 const uuid = require('../uuid.js');
 
@@ -76,9 +77,9 @@ function rowForVersion (site, page, version, options) {
     formatDate(version.diffWithPreviousSafeDate || version.diffWithPreviousDate) || '[initial version]',
     formatDate(version.diffWithFirstSafeDate || version.diffWithFirstDate) || '[initial version]',
     diff.length,
-    diff.hash !== emptyHash ? diff.hash : null,
+    diff.hash !== emptyHash ? diff.hash : '',
     textDiff.length,
-    textDiff.hash !== emptyHash ? textDiff.hash : null
+    textDiff.hash !== emptyHash ? textDiff.hash : ''
   ];
 
   if (options.includeDiffs) {
@@ -175,26 +176,12 @@ function toCsvString (rows) {
     .join('\n');
 }
 
-function compareRows (a, b) {
-  const a_text_hash = (a[15] || '').toLowerCase();
-  const b_text_hash = (b[15] || '').toLowerCase();
-
-  if (a_text_hash === b_text_hash) {
-    const a_diff_hash = (a[13] || '').toLowerCase();
-    const b_diff_hash = (b[13] || '').toLowerCase();
-
-    if (a_diff_hash === b_diff_hash) {
-      const a_time = new Date(a[10]);
-      const b_time = new Date(b[10]);
-      if (a_time === b_time) {
-        return 0;
-      }
-      return a_time < b_time ? -1 : 1;
-    }
-    return a_diff_hash < b_diff_hash ? -1 : 1;
-  }
-  return a_text_hash < b_text_hash ? -1 : 1;
-}
+// Standard comparator for sorting CSV output rows.
+const compareRows =  compareMany(
+  ascend(15),                   // text diff hash
+  ascend(13),                   // source diff hash
+  ascend(x => new Date(x[10]))  // capture time
+);
 
 function updateIndexColumn (value, index) {
   value[0] = index + 1;

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -1,0 +1,89 @@
+/**
+ * Create a comparison function composed from multiple simpler comparison. If
+ * the first comparison is equal, it uses the second comparison, and so on.
+ * @param  {...any} comparators comparison functions
+ * @returns {(any, any) => int}
+ * @example
+ * [{x: 5, y: 2}, {x: 5, y: 3}, {x: 2, y: 4}].sort(compareMany(
+ *   (a, b) => a.x - b.x,  // an explicit comparator
+ *   ascend('y')           // using a convenience function
+ * );
+ * [{x: 5, y: 2}, {x: 5, y: 3}, {x: 2, y: 4}].sort(compareMany(
+ *   ascend('x'),
+ *   ascend(a => a.y)
+ * );
+ * [{x: 5, y: 2}, {x: 5, y: 3}, {x: 2, y: 4}].sort(compareMany(
+ *   descend('x'),
+ *   ascend('y')
+ * );
+ */
+function compareMany (...comparators) {
+  return (a, b) => {
+    for (let comparator of comparators) {
+      const result = comparator(a, b);
+      if (result !== 0) return result;
+    }
+    return 0;
+  }
+}
+
+/**
+ * Create a comparison function that compares objects by the given property in
+ * ascending order, with smaller values first.
+ * @param {string|number|(any) => any} property Name of a property to compare
+ *   by or a function that, given an object, returns a value to compare by.
+ *   Strings and numbers are treated like the function: `x => x[property]`.
+ * @returns {(any, any) => int}
+ */
+function ascend (property) {
+  const getValue = getter(property);
+  return (a, b) => {
+    const valueA = getValue(a), valueB = getValue(b);
+    if (valueA < valueB) return -1;
+    if (valueA > valueB) return 1;
+    return 0;
+  }
+}
+
+/**
+ * Create a comparison function that compares objects by the given property in
+ * descending order, with larger values first.
+ * @param {string|number|(any) => any} property Name of a property to compare
+ *   by or a function that, given an object, returns a value to compare by.
+ *   Strings and numbers are treated like the function: `x => x[property]`.
+ * @returns {(any, any) => int}
+ */
+function descend (property) {
+  const comparator = ascend(property);
+  return (a, b) => -1 * comparator(a, b);
+}
+
+/**
+ * Create a function that takes an object and returns a value from:
+ * - `string|number` indicating the name of the property to return
+ * - `function` identical to the sort this function returns (if this is what
+ *    you pass in, you'll just get it right back).
+ * @param {string|number|(item) => any} key Property to get
+ * @returns {(any) => any}
+ */
+function getter (key) {
+  if (typeof key === 'function') return key;
+  return x => x[key];
+}
+
+/**
+ * Traverse an object by a series of properties to get a deeply nested value.
+ * @param {any} object
+ * @param  {...(string|number)} properties A list of properties to get
+ */
+function getDeep (object, ...properties) {
+  return properties.reduce((parent, key) => (parent != null ? parent[key] : null), object);
+}
+
+module.exports = {
+  compareMany,
+  ascend,
+  descend,
+  getter,
+  getDeep
+}


### PR DESCRIPTION
This has actually been running in production since Monday (since this was an emergency to get done). I’m not super happy with the way sorting code spilled all over the place, but it necessarily conflicts with the CSV formatting code (because the priority column’s type is really supposed to be something else as far as that module is concerned). Anyway, this is ugly, but it works.

Note I had to add retry logic because our systems now respond much less reliably (they are squished all onto two machines now and the constant diffing takes up a lot of resources).