### PR TITLE
HOTFIX: Sites table "since" field was unfindable

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -148,7 +148,9 @@ class Versionista {
 
         return rows.map(row => {
           const link = row.querySelector('a.kwbase');
-          const updateElement = row.querySelector('.kwlastChange');
+          // There's no longer any reliable class for "time since last change",
+          // but the cell has the ID `react_DashSiteChange{siteId}`
+          const updateElement = row.querySelector('[id*="DashSiteChange"] .h');
           const lastUpdateSecondsAgo =
             updateElement ? parseFloat(updateElement.textContent) : NaN;
 

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -151,8 +151,10 @@ class Versionista {
           // There's no longer any reliable class for "time since last change",
           // but the cell has the ID `react_DashSiteChange{siteId}`
           const updateElement = row.querySelector('[id*="DashSiteChange"] .h');
-          const lastUpdateSecondsAgo =
-            updateElement ? parseFloat(updateElement.textContent) : NaN;
+          if (!updateElement) {
+            throw new Error('Could not find "since" field on the sites page.');
+          }
+          const lastUpdateSecondsAgo = parseFloat(updateElement.textContent);
 
           return {
             id: parseVersionistaUrl(link.href).siteId,


### PR DESCRIPTION
The "since" column (i.e. time since last change) in the sites table has changed and is no longer available at the `class` where we were looking for it. That meant that we were checking every site for updated pages, which is a *huge* waste of time. This updates that selector.

NOTE: I think this may be why we were encountering some absurdly long scrape times and having a lot of resulting failures earlier this week.