### PR TITLE
HOTFIX: handle line breaks in page titles

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -321,7 +321,7 @@ function csvStringForPages (pages) {
       timeString,
       page.maintainers.map(maintainer => maintainer.name).join(', '),
       page.site,
-      page.title,
+      cleanString(page.title),
       page.url,
       // for now, the "page view" link is always to Versionista
       createViewUrl(page, null, null, true),
@@ -374,6 +374,11 @@ function formatHash (hash) {
     hash === '4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945';    // empty JSON array (`[]`)
 
   return isEmpty ? '[no change]' : hash;
+}
+
+function cleanString (text) {
+  if (!text) return '';
+  return text.trim().replace(/[\n\s]+/g, ' ');
 }
 
 function compressPath (targetPath) {

--- a/lib/formatters/csv.js
+++ b/lib/formatters/csv.js
@@ -166,8 +166,8 @@ function toCsvString (rows) {
           if (cell != null) {
             result = cell.toString();
           }
-          if (result.indexOf(',') > -1) {
-            result = `"${result}"`;
+          if (result.includes(',') || result.includes('\n') || result.includes('"')) {
+            result = `"${result.replace(/"/g, '""')}"`;
           }
           return result;
         })


### PR DESCRIPTION
It turns out some of our page titles have line breaks in them, which should not be the case. It’s a real situation we have, though, so this handles it by cleaning up the title strings to be treated like HTML would treat titles. (Side note: the underlying problem is that a) the ETL scripts should do this and b) the DB should sanitize the input this way, and I’ll file follow-on issues for those.)

Additionally, it's always possible that the data we put in a CSV could have a line break in a cell (or a quote!), so actually make sure to properly escape both of those cases. (Chances I should have used an off-the-shelf CSV library for this? 110%)