### PR TITLE
Enforce `--chunk-delay` getting earliest version

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -222,11 +222,12 @@ function getSiteUpdates () {
       if (linkToVersionista) return pages;
 
       return parallelMap(page => {
-        return getResponse(`/api/v0/pages/${page.uuid}/versions`, {
-          source_type: sourceType,
-          sort: 'capture_time:asc',
-          chunk_size: 1,
-        })
+        return delayPromise(chunkDelay || 0)
+          .then(() => getResponse(`/api/v0/pages/${page.uuid}/versions`, {
+            source_type: sourceType,
+            sort: 'capture_time:asc',
+            chunk_size: 1,
+          }))
           .then(body => {
             page.earliest = body.data[0];
             return page;


### PR DESCRIPTION
We already obeyed `--chunk-delay` for any request that iterate over multiple chunks (hence the name), but if it's meant to impose reasonable rate limiting, we should have been doing it when fetching the first version of every found page, too. (In fact, not doing this caused this script to fail a lot this week.)

A better fix is upcoming in edgi-govdata-archiving/web-monitoring-db#438 (which we'll have to write code to utilize here) -- that will let us get the earliest version without making an extra request for every page. This just tides us over for now.