### PR TITLE
Utilize new `?include_earliest` query param

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -175,7 +175,8 @@ function getSiteUpdates () {
   const timeframePages = getAllResults('api/v0/pages', {
     capture_time: `${startTime.toISOString()}..${endTime.toISOString()}`,
     source_type: sourceType,
-    chunk_size: chunkSize
+    chunk_size: chunkSize,
+    include_earliest: true
   })
   .catch(error => {
     console.error(`Failed to get all pages: ${error}`);
@@ -189,6 +190,7 @@ function getSiteUpdates () {
     source_type: sourceType,
     chunk_size: chunkSize,
     sort: 'capture_time:desc',
+    different: true,
     include_change_from_previous: true
   })
   .catch(error => {
@@ -216,23 +218,6 @@ function getSiteUpdates () {
       });
 
       return pages;
-    })
-    // Add an `earliest` property to each page with its first version
-    .then(pages => {
-      if (linkToVersionista) return pages;
-
-      return parallelMap(page => {
-        return delayPromise(chunkDelay || 0)
-          .then(() => getResponse(`/api/v0/pages/${page.uuid}/versions`, {
-            source_type: sourceType,
-            sort: 'capture_time:asc',
-            chunk_size: 1,
-          }))
-          .then(body => {
-            page.earliest = body.data[0];
-            return page;
-          });
-      }, 10, pages);
     })
     // Group pages by site
     .then(pages => {
@@ -596,39 +581,4 @@ function getAllResults (apiPath, qs) {
 
       return body.data;
     });
-}
-
-// Map an async transform function to each item of an array in parallel
-function parallelMap (transform, parallelOperations, data) {
-  const result = new Array(data.length);
-  let index = 0;
-  let inProgress = 0;
-
-  return new Promise((resolve, reject) => {
-    // If we have parallel work slots available, grab an item and work on it
-    const transformNextItem = () => {
-      if (inProgress >= parallelOperations) return;
-
-      if (index >= data.length) {
-        if (inProgress === 0) resolve(result);
-        return;
-      }
-
-      inProgress++;
-      const itemIndex = index++;
-      Promise.resolve(data[itemIndex])
-        .then(transform)
-        .then(output => {
-          result[itemIndex] = output;
-          inProgress--;
-          transformNextItem();
-        })
-        .catch(reject);
-    };
-
-    // Start working on as many items as possible
-    while (inProgress < Math.min(data.length, parallelOperations)) {
-      transformNextItem();
-    }
-  });
 }


### PR DESCRIPTION
We spend a stupid amount of time and effort finding the earliest version of each page when generating analyst sheets. Now -db has a PR for adding an `?include_earliest` option, which will do all that work for us! This makes use of it, simplifying and speeding things up nicely :)

See also edgi-govdata-archiving/web-monitoring-db#438