### PR TITLE
Use Versionista CSV data to add more metadata to versions

### DIFF
--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -61,10 +61,11 @@ function importableVersion (version) {
     page_url: version.pageUrl,
     page_maintainers: [version.agency],
     page_tags: [`site:${version.siteName}`],
-    title: version.pageTitle,
+    title: version.title || version.pageTitle,
     capture_time: version.date,
     uri: s3Url,
     version_hash: version.hash,
+    status: version.status,
     source_type: 'versionista',
     source_metadata: {
       account: version.account,
@@ -82,7 +83,11 @@ function importableVersion (version) {
       diff_text_length: version.textDiff && version.textDiff.length,
       length: version.length,
       headers: version.headers,
-      content_type: version.contentType
+      content_type: version.contentType,
+      status: version.status,
+      loadTime: version.loadTime,
+      redirects: version.redirects,
+      last_date: version.lastDate.toISOString()
     }
   };
 }

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -85,7 +85,7 @@ function importableVersion (version) {
       headers: version.headers,
       content_type: version.contentType,
       status: version.status,
-      loadTime: version.loadTime,
+      load_time: version.loadTime,
       redirects: version.redirects,
       last_date: version.lastDate
     }

--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -87,7 +87,7 @@ function importableVersion (version) {
       status: version.status,
       loadTime: version.loadTime,
       redirects: version.redirects,
-      last_date: version.lastDate.toISOString()
+      last_date: version.lastDate
     }
   };
 }

--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -314,7 +314,8 @@ function archivePageVersions (page, versions) {
             version.hash = content.hash;
             version.length = content.length;
             version.headers = content.headers;
-            version.contentType = content.headers['content-type'];
+            version.contentType = version.contentType ||
+              content.headers['content-type'];
 
             return fs.writeFile(outputPath, content.body);
           })
@@ -426,6 +427,7 @@ let versions = pages
             .then(() => [safes, errors]);
         });
 
+      // FIXME: handle errors originating here
       updatedVersions
         .then(([safes, errors]) => safes)
         .then(onlyMeaningfulDiffs)
@@ -433,6 +435,7 @@ let versions = pages
           page.versions = versions;
         });
 
+      // FIXME: handle errors originating here
       updatedVersions
         .then(([safes, errors]) => errors)
         .then(onlyMeaningfulDiffs)

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -1,13 +1,17 @@
 'use strict';
 
+const csvParse = require('csv-parse');
 const crypto = require('crypto');
 const stream = require('stream');
 const jsdom = require('jsdom');
 const mime = require('mime-types');
 const unzip = require('unzip-stream');
+const util = require('util');
 const createClient = require('./client');
 const flatten = require('./flatten');
 const {xpath, xpathArray, xpathNode} = require('./xpath');
+
+const csvParsePromise = util.promisify(csvParse);
 
 /**
  * @typedef {Object} VersionistaSite
@@ -34,6 +38,13 @@ const {xpath, xpathArray, xpathNode} = require('./xpath');
  * @property {Date} date
  * @property {Boolean} hasContent
  * @property {Number} errorCode
+ * @property {Date} lastDate
+ * @property {Number} status
+ * @property {Number} length
+ * @property {String} contentType
+ * @property {Number} loadTime
+ * @property {Array<String>} redirects
+ * @property {String} title
  * @property {String} [diffWithPreviousUrl]
  * @property {Date} [diffWithPreviousDate]
  * @property {String} [diffWithFirstUrl]
@@ -192,6 +203,8 @@ class Versionista {
    * @returns {Promise<VersionistaVersion[]>}
    */
   getVersions (pageUrl) {
+    const page = parseVersionistaUrl(pageUrl);
+
     const versionDataForRow = (versionRow) => {
       const linkNode = xpathNode(versionRow, "./td[2]/a");
       let url = linkNode && linkNode.href;
@@ -229,7 +242,40 @@ class Versionista {
       return `https://versionista.com/${version.siteId}/${version.pageId}/${version.versionId}:${compareTo.versionId}/`;
     }
 
-    return this.request(pageUrl).then(window => {
+    function getVersionCsvUrl(page) {
+      return `https://versionista.com/download/page-${page.siteId}-${page.pageId}.csv`;
+    }
+
+    function parseVersionsCsv(csvString) {
+      return csvParsePromise(csvString.toString(), {
+        cast: true,
+        cast_date: true,
+        columns (names) {
+          // lower-case, replace spaces with `_`, remove parentheticals:
+          // 'Load time' -> 'load_time'
+          const result = names.map(name =>
+            name.toLowerCase().replace(/\s+\(.+?\)/g, '').replace(/\s/g, '_'));
+
+          // Validate
+          const columns = [
+            'first_seen',
+            'last_seen',
+            'response_code',
+            'size',
+            'mime_type',
+            'load_time',
+            'redirected_to'
+          ];
+          columns.forEach(name => {
+            if (!result.includes(name)) throw new Error(`Page CSV is missing required columns: ${columns.join(', ')}`);
+          });
+
+          return result;
+        }
+      });
+    }
+
+    const versionsFromPage = this.request(pageUrl).then(window => {
       const versionRows = Array.from(window.document.querySelectorAll(
         '#pageTableBody > tr.version'));
       let oldestVersion;
@@ -239,6 +285,8 @@ class Versionista {
 
       return versionRows.reverse().map(row => {
         const version = versionDataForRow(row);
+
+        // Create links and diff info for previous and first versions
         if (previousVersion) {
           version.diffWithPreviousUrl = formatComparisonUrl(version, previousVersion);
           version.diffWithPreviousDate = version.date;
@@ -265,6 +313,38 @@ class Versionista {
         return version;
       });
     });
+
+    const csvMetadata = this.request({url: getVersionCsvUrl(page), parseBody: false})
+      .then(response => parseVersionsCsv(response.body))
+      .then(csv => {
+        // Create timestamp lookup for CSV data (the CSVs have no IDs)
+        const csvByDate = new Map();
+        csv.forEach(row => csvByDate.set(row.first_seen.getTime(), row));
+        return csvByDate;
+      });
+
+    // Combine in-page and CSV-based data
+    return Promise.all([versionsFromPage, csvMetadata])
+      .then(([versions, csv]) => {
+        return versions.map(version => {
+          const csvRow = csv.get(version.date.getTime());
+          if (!csvRow) {
+            throw new Error(`No CSV row for version '${version.siteId}/${version.pageId}/${version.versionId}'`);
+          }
+
+          Object.assign(version, {
+            lastDate: csvRow.last_seen,
+            status: parseInt(csvRow.response_code, 10),
+            length: csvRow.size,
+            contentType: csvRow.mime_type,
+            loadTime: csvRow.load_time,
+            redirects: csvRow.redirected_to ? [csvRow.redirected_to] : null,
+            title: csvRow.title || null
+          });
+
+          return version;
+        });
+      });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@google-cloud/storage": "^2.3.1",
     "aws-sdk": "^2.368.0",
+    "csv-parse": "^4.0.1",
     "fast-crc32c": "^1.0.4",
     "fs-promise": "^2.0.3",
     "jsdom": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,6 +324,11 @@ cssstyle@^1.1.1:
   dependencies:
     cssom "0.3.x"
 
+csv-parse@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.0.1.tgz#4ad438352cbf12d5317d0fb9d588e53473293851"
+  integrity sha512-ehkwejEj05wwO7Q9JD+YSI6dNMIauHIroNU1RALrmRrqPoZIwRnfBtgq5GkU6i2RxZOJqjo3dtI1NrVSXvaimA==
+
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"


### PR DESCRIPTION
Versionista now has a CSV you can download for each page that lists useful extra metadata, like content type and response code (and a few others)! This is SUPER useful, since we can't reliably get some of this data from the rest of the page. Unfortunately it doesn't include *everything* relevant, so this downloads the CSV alongside the page, then combines the data we get from each.

I'm not sure when this feature got added -- there used to be a CSV for the whole account (and it's still there), but it has even less info and does not fill us in with what we need, so we skip over it. It's a different story with the page-level one, though.

This isn’t as absolutely clean as it could be, but:

- I’d like to get it in quick
- We might not need this for the long term