### PR TITLE
Add unparse-able body text to parse error message when importing

### DIFF
--- a/bin/import-to-db
+++ b/bin/import-to-db
@@ -255,7 +255,14 @@ function importIntoDb (versions, callback) {
       return callback(error)
     }
 
-    const body = JSON.parse(rawBody);
+    let body;
+    try {
+      body = JSON.parse(rawBody);
+    }
+    catch (error) {
+      error.message = `${error.message} (while parsing: \`${rawBody}\`)`;
+      throw error;
+    }
 
     if (body.errors) {
       return callback(body.errors[0]);


### PR DESCRIPTION
Occasionally imports fail with response bodies that aren't valid JSON. I don't know that getting the actual response text will help us (I suspect these are just intermittent network errors, a process getting killed by the system, etc.), but you never know! This adds the original response text to the error message so we'll see it in logs and in Sentry.

(See this error for an example: https://sentry.io/environmental-data-governance-/versionista-scraper/issues/722694225/)