### PR TITLE
HOTFIX: handle missing "last updated since" field

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -162,10 +162,21 @@ class Versionista {
           // There's no longer any reliable class for "time since last change",
           // but the cell has the ID `react_DashSiteChange{siteId}`
           const updateElement = row.querySelector('[id*="DashSiteChange"] .h');
-          if (!updateElement) {
-            throw new Error('Could not find "since" field on the sites page.');
+          let lastUpdateSecondsAgo = 0;
+          if (updateElement) {
+            lastUpdateSecondsAgo = parseFloat(updateElement.textContent);
           }
-          const lastUpdateSecondsAgo = parseFloat(updateElement.textContent);
+          else {
+            // It appears that if there were no updates in the past year or so,
+            // the `.h` element will be replaced with `.anev`. This is
+            // imperfect, but basically just treat it as "1 year ago."
+            if (row.querySelector('[id*="DashSiteChange"] .anev')) {
+              lastUpdateSecondsAgo = 1000 * 60 * 60 * 24 * 365;
+            }
+            else {
+              throw new Error('Could not find "since" field on the sites page.');
+            }
+          }
 
           return {
             id: parseVersionistaUrl(link.href).siteId,


### PR DESCRIPTION
Some sites just started not having a "last updated since" field. It *seems* like this correlates to not having any updates in the past year or so (though I could be totally wrong there...), and if it's the case, there is a `<span class="anev">` element (maybe the class is for "never updated?") instead. This hotfix changes things to assume that means the last update was probably a year ago instead of simply failing with an error.

I *think* this is reasonable, though the more conservative case would be to mark it as having potentially just been updated so the site always gets checked.