### PR TITLE
HOTFIX: redirect paths are no longer absolute

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -381,8 +381,13 @@ class Versionista {
           throw error;
         }
 
+        let rawUrl = response.body;
+        if (!/^https?:\/\//.test(rawUrl)) {
+          rawUrl = `https://versionista.com${rawUrl}`;
+        }
+
         return this.request({
-          url: response.body,
+          url: rawUrl,
           // The URL from the API is time limited, so prioritize the request
           immediate: true,
           // A version may be binary data (for PDFs, videos, etc.)


### PR DESCRIPTION
Versionista’s “API” returns the URL for a raw version when you request it. That used to be a complete, absolute URL, but it just changed to being only a path. This checks for whether it’s absolute and, if not, prepends `https://versionista.com` to the path.