### PR TITLE
Handle the fact that the page details view no longer has content

### DIFF
--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -429,6 +429,10 @@ let versions = pages
 
       // FIXME: handle errors originating here
       updatedVersions
+        // Any errors leading into here will get handled and logged gracefully
+        // at the top level. Here, we just need to short circuit the following
+        // logic if there was an error.
+        .catch(() => [[], []])
         .then(([safes, errors]) => safes)
         .then(onlyMeaningfulDiffs)
         .then(versions => {
@@ -437,6 +441,10 @@ let versions = pages
 
       // FIXME: handle errors originating here
       updatedVersions
+        // Any errors leading into here will get handled and logged gracefully
+        // at the top level. Here, we just need to short circuit the following
+        // logic if there was an error.
+        .catch(() => [[], []])
         .then(([safes, errors]) => errors)
         .then(onlyMeaningfulDiffs)
         .then(versions => {

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -154,6 +154,11 @@ class Versionista {
   getSites () {
     return this.request('https://versionista.com/home?show_all=1')
       .then(window => {
+        const table = window.document.querySelector('.sorttable');
+        if (!table) {
+          throw new Error(`HTML for site listing has no table of sites`);
+        }
+
         const rows = Array.from(
           window.document.querySelectorAll('.sorttable > tbody > tr'));
 
@@ -701,6 +706,11 @@ function getPagingUrls (window) {
 };
 
 function getPageDetailData (window) {
+  const table = window.document.querySelector('table#siteView');
+  if (!table) {
+    throw new Error(`Could not find table of pages on site page listing ${window.location.href}`);
+  }
+
   const xpathRows = xpath(window.document, "//div[contains(text(), 'URL')]/../../../following-sibling::tbody/tr");
   return xpathRows.map(row => {
     let lastChange = null;

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -241,13 +241,14 @@ class Versionista {
      * }
      */
     const apiVersionSchema = {
-      stored: 'boolean',
       rc: 'string',
       size: 'number',
       fst: 'number',
       content_type: 'string',
       lst: 'number',
       id: undefined
+      // Only present if true
+      // stored: 'boolean'
       // Only present if it has a value
       // seen: 'number',
       // title: 'string'

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -223,7 +223,7 @@ class Versionista {
 
     /**
      * Versionista seems to be growing a bit of an API, but it may not be very
-     * stable yet. Observed schema for vesions:
+     * stable yet. Observed schema for versions:
      * {
      * stored: boolean,      // Whether the content is stored and available
      * rc: string,           // Response code as text, e.g. '200 OK'

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -287,8 +287,12 @@ class Versionista {
     }
 
     const versionsFromPage = this.request(pageUrl).then(window => {
-      const versionRows = Array.from(window.document.querySelectorAll(
-        '#pageTableBody > tr.version'));
+      const table = window.document.getElementById('pageTableBody');
+      if (!table) {
+        throw new Error(`HTML for page ${pageUrl} has no versions table`);
+      }
+
+      const versionRows = Array.from(table.querySelectorAll('tr.version'));
       let oldestVersion;
       let previousVersion;
       let oldestSafeVersion;

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -221,6 +221,123 @@ class Versionista {
   getVersions (pageUrl) {
     const page = parseVersionistaUrl(pageUrl);
 
+    /**
+     * Versionista seems to be growing a bit of an API, but it may not be very
+     * stable yet. Observed schema for vesions:
+     * {
+     * stored: boolean,      // Whether the content is stored and available
+     * rc: string,           // Response code as text, e.g. '200 OK'
+     * seen: number,         // Optional; Unix epoch time when page was viewed on Versionista, e.g. 1491736083
+     * render_stamp: number, // Optional; don't know what this is! Looks like a timestamp, maybe of when the screenshot was rendered? e.g. 1485722161687
+     * final_url: string,    // Only present on redirects. This is the final target URL of the redirect.
+     * size: number,         // Size of response in bytes.
+     * fst: number,          // Unix epoch time when version was first captured
+     * protected: boolean,   // Whether the version is protected from deletion on Versionista
+     * content_type: string, // Content-type header from response, e.g. 'text/html'
+     * lst: number,          // Unix epoch time when version was last captured, e.g. 1485722160
+     * id: number,           // ID of Version on Versionista, e.g. 9651274
+     * title: string,        // Title of page
+     * beacon: number        // Don't know what this is! Appears to always be 0 or 1.
+     * }
+     */
+    const apiVersionSchema = {
+      stored: 'boolean',
+      rc: 'string',
+      size: 'number',
+      fst: 'number',
+      content_type: 'string',
+      lst: 'number',
+      id: undefined
+      // Only present if it has a value
+      // seen: 'number',
+      // title: 'string'
+    };
+    const versionsApiUrl = `https://versionista.com/api/versions/${page.siteId}/${page.pageId}`;
+    return this.request({url: versionsApiUrl, json: true}).then(response => {
+      const apiVersions = response.body;
+      if (!Array.isArray(apiVersions)) {
+        throw new Error(`Response from version listing API was not a JSON array: ${versionsApiUrl}`)
+      }
+      // TODO: once we are reasonably confident in the schema, just assert on
+      // the first item for performance.
+      // if (apiVersions.length) {
+      //   assertSchema(apiVersionSchema, apiVersions[0]);
+      // }
+
+      let oldestVersion;
+      let previousVersion;
+      let oldestSafeVersion;
+      let previousSafeVersion;
+      return apiVersions
+        // The API appears to return metadata for old, deleted records (!) but
+        // that metadata is ultra-limited and I'm not sure how/if to use it
+        // effectively yet. We didn't have this before, so drop it for now.
+        // FIXME: keep this data (we might need a different schema for it)
+        .filter(version => !version.deleted)
+        .map((apiVersion, index) => {
+          assertSchema(
+            apiVersionSchema,
+            apiVersion,
+            `Version does not match expected schema. Index: ${index}, URL: ${versionsApiUrl}`);
+
+          // This is a string like '200 OK', so we can safely parse the code
+          // off the front of it.
+          const status = parseInt(apiVersion.rc, 10);
+          if (isNaN(status)) {
+            throw new Error(`Could not parse status code from version. String: '${apiVersion.rc}', ${index}, URL: ${versionsApiUrl}`);
+          }
+
+          return Object.assign({}, page, {
+            versionId: apiVersion.id,
+            url: `https://versionista.com/${page.siteId}/${page.pageId}/${apiVersion.id}/`,
+            date: new Date(apiVersion.fst * 1000),
+            hasContent: apiVersion.stored,
+            // Because of historical fun, errorCode is a string and only present
+            // if it was an error status code.
+            errorCode: (status && status >= 400) ? status.toString(10) : null,
+            lastDate: new Date(apiVersion.lst * 1000),
+            status: status,
+            length: apiVersion.size,
+            contentType: apiVersion.content_type,
+            redirects: apiVersion.final_url ? [apiVersion.final_url] : null,
+            title: apiVersion.title
+            // NOTE: the CSV has load timing, which the API does not. That's the
+            // only missing piece, though. Is it worth fetching the CSV for that?
+            // loadTime: csvRow.load_time
+          });
+        })
+        .reverse()
+        .map(version => {
+          // Create links and diff info for previous and first versions
+          if (previousVersion) {
+            version.diffWithPreviousUrl = formatComparisonUrl(version, previousVersion);
+            version.diffWithPreviousDate = version.date;
+            version.diffWithFirstUrl = formatComparisonUrl(version, oldestVersion);
+            version.diffWithFirstDate = oldestVersion.date;
+
+            if (previousSafeVersion && previousSafeVersion !== previousVersion) {
+              version.diffWithPreviousSafeUrl = formatComparisonUrl(version, previousSafeVersion);
+              version.diffWithPreviousSafeDate = version.date;
+              version.diffWithFirstSafeUrl = formatComparisonUrl(version, oldestSafeVersion);
+              version.diffWithFirstSafeDate = oldestSafeVersion.date;
+            }
+          }
+          else {
+            oldestVersion = version;
+          }
+
+          previousVersion = version;
+          if (!version.errorCode) {
+            previousSafeVersion = version;
+            oldestSafeVersion = oldestSafeVersion || version;
+          }
+
+          return version;
+        });
+    });
+
+    // FIXME: this code is unreachable now, and we may want to excise it or
+    // split it out so it can be used as a fallback somehow.
     const versionDataForRow = (versionRow) => {
       const linkNode = xpathNode(versionRow, "./td[2]/a");
       let url = linkNode && linkNode.href;
@@ -798,6 +915,34 @@ function versionDataFromLink (versionLink) {
 
 function oneLine (string) {
   return string.replace(/\n\s+/g, ' ');
+}
+
+/**
+ * Asserts that an object implements a given schema or throws an error if not.
+ * The types are always strings, as returned by `typeof`. If the type is null
+ * or undefined, then the presence of the property, but not its type will be
+ * checked. The schema defines a minimum set of properties that the object must
+ * support -- the object can have other properties not present in the schema.
+ * @param {object} schema An object mapping keys to types, e.g.
+ *        `{name: 'string', age: 'number'}`
+ * @param {any} object Object that is expected to implement the schema
+ * @param {string} [message] Optional message for the error that will be thrown
+ *        if the schema does not match.
+ */
+function assertSchema(schema, object, message = null) {
+  const keys = [
+    ...Object.getOwnPropertyNames(schema),
+    ...Object.getOwnPropertySymbols(schema)
+  ];
+
+  keys.forEach(key => {
+    if (!(key in object)) {
+      throw new Error(message || `Object is missing property '${key}'`);
+    }
+    if (schema[key] && !(typeof object[key] === schema[key])) {
+      throw new Error(message || `The '${key}' property of object was not a ${schema[key]}`);
+    }
+  });
 }
 
 module.exports = Versionista;


### PR DESCRIPTION
The *page* view in Versionista (e.g. `https://versionista.com/73900/6185299/`) no longer includes the list of versions. Instead, versions are now loaded via XHR in JavaScript after the page loads. This PR is the quickest reasonable fix to get things working again; it probably needs cleanup later.

Versionista now loads the list of pages from a JSON API located at `https://versionista.com/api/versions/{site_id}/{page_id}/`. I poked around and didn’t see any obvious corresponding endpoints for sites or pages, but I’d bet those are probably coming soon. The root of the API (`https://versionista.com/api`) is just a page that says:

> Our API is still very much a work in progress and is in beta, so it is not feature-complete and is subject to revision.

So I’ve treated the API similarly to scraping a page in this PR. We do a bit of checking to make sure what we’re getting looks like what we’d expect, and throw exceptions if not. I’ve also added more checks to the site listing and page listing views so they can’t fail silently the way version listing view did if they change in a similar way.

Fixes #195.

@jjudish if you can try out this branch, let me know if it works for you!