### PR TITLE
Show number of versions in weekly analyst sheets

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -332,6 +332,7 @@ function csvStringForPages (pages) {
       formatHash(annotation.source_diff_hash),
       annotation.text_diff_length,
       formatHash(annotation.text_diff_hash),
+      page.versions.length,
       annotation.priority
     ];
   };
@@ -359,7 +360,7 @@ function csvStringForPages (pages) {
     )));
   const sortedRows = flatten(sortedGroups).map(createRow);
 
-  const headers = [...formatCsv.headers, 'priority'];
+  const headers = [...formatCsv.headers, 'number of versions', 'priority'];
   return formatCsv.toCsvString([headers, ...sortedRows]);
 }
 


### PR DESCRIPTION
Since our sheets only show one row per *page,* and a given page may have had multiple versions/changes captured over the timeframe we are generating a sheet for (usually one week), it would help analysts out to know in advance how many changes happened during the given timeframe. A future PR will try and change the "last two" diff link and the priority to account for *all* the changes covered in the timeframe (instead of just the last one).

Fixes #207.