### PR TITLE
Handle diffs properly when scripts are enabled

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -731,7 +731,7 @@ class Versionista {
         }
 
         diffHost = `${actualUri.protocol}//${actualUri.host}`;
-        return `${diffHost}/api/ip_url${actualUri.path}${diffType}`;
+        return `${diffHost}/api/ip_url${actualUri.pathname}${diffType}${actualUri.search || ''}`;
       })
       .then(apiUrl => this.request({
         url: apiUrl,


### PR DESCRIPTION
Versionista now has an “enable scripts” option for diffs, which is a querystring in the actual URL. We were accidentally appending the diff type to the end of the querystring instead of the end of the path (which is *before* the querystring), causing malformed URLs. This uses the right parts of the URL so everything works.

There’s probably some deeper thinking to be done here about whether we should use the querystring at all (A: this setting doesn’t apply to the diffs we use and B: we probably want the caller of `getVersionDiff` to provide the diff settings they want, not just get whatever was last used by someone logged into Versionista). I’m comfortable punting on that for now since it doesn’t affect anything in practice right now.

Fixes #222.

@jjudish, does this solve the problem for you?