### PR TITLE
If tag names match exactly, include full tag name in DB query file names.

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -231,7 +231,8 @@ function getGroupUpdates () {
           .reduce((groups, tag) => {
             tagGroups.some((group, index) => {
               if (tag.name.startsWith(group)) {
-                groups[index] = tag.name.slice(group.length);
+                const groupName = (group === tag.name) ? tag.name : tag.name.slice(group.length);
+                groups[index] = groupName;
                 return true;
               }
             });


### PR DESCRIPTION
When matching a page’s tags during DB queries (using the `--group-by` option), we treat the option as a prefix, and only include everything *after* the prefix in our output. For example, if using `--group-by '2l-domain:'`, and matching a page tagged `2l-domain:epa.gov`, we’d put the page in the `epa.gov` group (everything after the matched prefix).

Now, however, we are starting to use tags that aren’t “categorical” the way `2l-domain:<xyz>` is. For example, we want to group on the `news` tag, which designates whether a page is a blog/newsfeed/etc. The tag is merely present or not, rather than designating a standard prefix with different suffix values.

To support that, this change uses the full tag name (instead of the suffix) in situations where the match is an exact one, rather than just a prefix. So, when matching `2l-domain:`, we still use the group `epa.gov`, but when matching `news`, we use `news` as the group, because it is the complete tag name.