### PR TITLE
Use a cache for API requests so we can resume a broken analyst sheet generation job

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -8,6 +8,7 @@ const fs = require('fs-promise');
 const neodoc = require('neodoc');
 const nodemailer = require('nodemailer');
 const path = require('path');
+const qs = require('qs');
 const request = require('request');
 const spawn = require('child_process').spawn;
 const stream = require('stream');

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -624,8 +624,7 @@ function getResponse (apiPath, query) {
       });
     }
 
-    const cacheName = url.replace(/^http(s?):\/\/[^\/]\/?/, '');
-    withCache(requestCache, cacheName, getWithRetries, [url, requestOptions, 3], function (error, response) {
+    withCache(requestCache, url, getWithRetries, [url, requestOptions, 3], function (error, response) {
       if (args['--debug']) {
         console.log(`Got ${url}`);
       }
@@ -713,7 +712,7 @@ let cacheData = null;
 function getCacheObject (cachePath) {
   if (cacheData) return Promise.resolve(cacheData);
 
-  return fs.readFile(cacheData, {encoding: 'utf8'})
+  return fs.readFile(cachePath, {encoding: 'utf8'})
     .then(JSON.parse)
     .catch(() => ({}))
     .then(fileData => {
@@ -735,7 +734,7 @@ async function setCache (cachePath, key, value) {
   cache[key] = value;
   clearTimeout(cacheWriteTimer);
   cacheWriteTimer = setTimeout(() => {
-    fs.ensureDir(path.relative(cachePath, '..'))
+    fs.ensureDir(path.resolve(cachePath, '..'))
       .then(() => fs.writeFile(cachePath, JSON.stringify(cache), {encoding: 'utf8'}))
       .catch(error => console.error('Failed to write cache:', error));
   }, 5000);

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -708,17 +708,43 @@ function promised (func, ...args) {
 }
 
 // TODO: this should really take a serializer and deserializer
-function withCache (cachePath, name, operation, args, callback) {
-  const fileName = name.replace(/[\/\\:?()[\]&]/g, '-');
-  const filePath = path.join(cachePath, fileName);
+let cacheData = null;
+function getCacheObject (cachePath) {
+  if (cacheData) return Promise.resolve(cacheData);
 
-  fs.stat(filePath)
-    .then(() => fs.readFile(filePath, {encoding: 'utf8'}))
+  return fs.readFile(cacheData, {encoding: 'utf8'})
     .then(JSON.parse)
+    .catch(() => ({}))
+    .then(fileData => {
+      cacheData = fileData;
+      return fileData;
+    });
+}
+
+async function getCache (cachePath, key) {
+  const cache = await getCacheObject(cachePath);
+  const value = cache[key];
+  if (value == null) throw new Error(`Unset cache key: ${key}`);
+  return value;
+}
+
+let cacheWriteTimer = 0;
+async function setCache (cachePath, key, value) {
+  const cache = await getCacheObject(cachePath)
+  cache[key] = value;
+  clearTimeout(cacheWriteTimer);
+  cacheWriteTimer = setTimeout(() => {
+    fs.ensureDir(path.relative(cachePath, '..'))
+      .then(() => fs.writeFile(cachePath, JSON.stringify(cache), {encoding: 'utf8'}))
+      .catch(error => console.error('Failed to write cache:', error));
+  }, 5000);
+}
+
+function withCache (cachePath, name, operation, args, callback) {
+  getCache(cachePath, name)
     .catch(async () => {
       const result = await promised(operation, ...args);
-      await fs.ensureDir(cachePath);
-      await fs.writeFile(filePath, JSON.stringify(result), {encoding: 'utf8'});
+      await setCache(cachePath, name, result);
       return result;
     })
     .then(
@@ -732,7 +758,8 @@ async function clearCache (cachePath) {
     await fs.remove(cachePath);
   }
   catch (error) {
-    // Failure is OK.
+    // Failure is OK, but log it.
+    console.error('Error clearing cache:', error);
   }
 }
 

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -69,6 +69,7 @@ const timeString = scrapeTime.toISOString().slice(0, 16) + 'Z';
 const safeScrapeTime = timeString.replace(/:/g, '-');
 const safeTagGroups = tagGroups.map(group => group.replace(/:/g, '')).join('-');
 const outputDirectory = path.join(outputParent, `webmonitoring-${safeTagGroups}s-${safeScrapeTime}`);
+const requestCache = path.join(outputDirectory, '.cache');
 
 
 let startTime;
@@ -139,6 +140,9 @@ Completed in ${result.queryDuration / 1000} seconds`,
     // write to console, but also send in e-mail
     console.error(error.stack || error)
     return error;
+  })
+  .then(async results => {
+    await clearCache(requestCache);
   })
   .then(sendResults)
   .catch(error => console.error(error.stack || error))
@@ -599,15 +603,26 @@ function getCredentialsFromUrl (url) {
   return null;
 }
 
+function alphabeticalSort(a, b) {
+  return a.localeCompare(b);
+}
+
 function getResponse (apiPath, qs) {
-  const requestOptions = {qs, qsStringifyOptions: {arrayFormat: 'brackets'}};
+  const requestOptions = {};
   if (dbCredentials) {
     requestOptions.auth = dbCredentials;
   }
 
   return new Promise((resolve, reject) => {
-    const url = /^http(s?):\/\//.test(apiPath) ? apiPath : `${dbUrl}${apiPath}`;
-    getWithRetries(url, requestOptions, 3, function (error, response) {
+    let url = /^http(s?):\/\//.test(apiPath) ? apiPath : `${dbUrl}${apiPath}`;
+    if (qs) {
+      url += '?' + qs.stringify(qs, {
+        arrayFormat: 'brackets',
+        sort: alphabeticalSort
+      });
+    }
+
+    withCache(requestCache, url, getWithRetries, [url, requestOptions, 3], function (error, response) {
       if (args['--debug']) {
         console.log(`Got ${url}`);
       }
@@ -633,6 +648,7 @@ function getResponse (apiPath, qs) {
 }
 
 // TODO: clean this up?
+// TODO: rewrite as promises
 function getWithRetries(url, options, retries, callback) {
   if (typeof retries === 'function') {
     [callback, retries] = [retries, 2];
@@ -640,7 +656,7 @@ function getWithRetries(url, options, retries, callback) {
   let retryCount = 0;
 
   function handleResult (error, response) {
-    if ((error || response.status >= 500) && retryCount <= retries) {
+    if ((error || response.statusCode >= 500) && retryCount <= retries) {
       const delay = retryCount > 0 ? 1000 * Math.pow(2, retryCount - 1) : 0
       setTimeout(() => {
         retryCount++;
@@ -653,6 +669,69 @@ function getWithRetries(url, options, retries, callback) {
   }
 
   request.get(url, options, handleResult);
+}
+
+// function getAsPromise (url, options) {
+//   return new Promise((resolve, reject) => {
+//     request.get(url, options, (error, response) => {
+//       if (error) return reject(error);
+//       resolve(response);
+//     });
+//   });
+// }
+
+// async function withFileCache (basePath, name, operation, args) {
+//   const fileName = name.replace(/[\/\\:?()[\]&]/g, '-');
+//   const filePath = path.join(basePath, fileName);
+//   try {
+//     await fs.stat(filePath);
+//     const body = await fs.readFile(filePath, {encoding: 'utf8'});
+//     return {body, status: 200, statusCode: 200};
+//   }
+//   catch (error) {
+//     const result = await operation(args);
+//     await fs.ensureDir(basePath);
+//     await fs.writeFile(filePath, result.body, {encoding: 'utf8'});
+//     return result;
+//   }
+// }
+
+function promised (func, ...args) {
+  return new Promise((resolve, reject) => {
+    func(...args, (error, result) => {
+      if (error) return reject(error);
+      resolve(result);
+    });
+  });
+}
+
+// TODO: this should really take a serializer and deserializer
+function withCache (cachePath, name, operation, args, callback) {
+  const fileName = name.replace(/[\/\\:?()[\]&]/g, '-');
+  const filePath = path.join(cachePath, fileName);
+
+  fs.stat(filePath)
+    .then(() => fs.readFile(filePath, {encoding: 'utf8'}))
+    .then(JSON.parse)
+    .catch(async () => {
+      const result = await promised(operation, ...args);
+      await fs.ensureDir(cachePath);
+      await fs.writeFile(filePath, JSON.stringify(result), {encoding: 'utf8'});
+      return response;
+    })
+    .then(
+      response => callback(null, response),
+      error => callback(error)
+    );
+}
+
+async function clearCache (cachePath) {
+  try {
+    await fs.remove(cachePath);
+  }
+  catch (error) {
+    // Failure is OK.
+  }
 }
 
 function delayPromise (timeout) {

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -70,7 +70,7 @@ const timeString = scrapeTime.toISOString().slice(0, 16) + 'Z';
 const safeScrapeTime = timeString.replace(/:/g, '-');
 const safeTagGroups = tagGroups.map(group => group.replace(/:/g, '')).join('-');
 const outputDirectory = path.join(outputParent, `webmonitoring-${safeTagGroups}s-${safeScrapeTime}`);
-const requestCache = path.join(outputDirectory, '.cache');
+const requestCache = path.join(outputParent, '.cache');
 
 
 let startTime;

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -617,9 +617,11 @@ function getResponse (apiPath, query) {
 
   return new Promise((resolve, reject) => {
     let url = /^http(s?):\/\//.test(apiPath) ? apiPath : `${dbUrl}${apiPath}`;
+    // Serialize the querstring ourselves so we can use it in the cache key.
     if (query) {
       url += '?' + qs.stringify(query, {
         arrayFormat: 'brackets',
+        // Sort so we have consistent cache keys.
         sort: alphabeticalSort
       });
     }
@@ -707,6 +709,7 @@ function promised (func, ...args) {
   });
 }
 
+// TODO: should also rewrite all this cache stuff as a class
 // TODO: this should really take a serializer and deserializer
 let cacheData = null;
 function getCacheObject (cachePath) {
@@ -721,6 +724,31 @@ function getCacheObject (cachePath) {
     });
 }
 
+let cacheWriteTimer = -1;
+const persistCacheAfter = 5000;
+async function writeCacheObject (cachePath, cache, now = false) {
+  if (now) {
+    try {
+      // Clear the timer *first* because fs.writeFile is async -- there is an
+      // opportunity for new data to be added to the memory cache between when
+      // the write finishes and the next instruction. Better to schedule an
+      // extra write than to miss a write!
+      cacheWriteTimer = -1;
+      await fs.ensureDir(path.resolve(cachePath, '..'));
+      await fs.writeFile(cachePath, JSON.stringify(cache), {encoding: 'utf8'});
+    }
+    catch (error) {
+      console.error('Failed to write cache:', error);
+    }
+  }
+  else if (cacheWriteTimer === -1) {
+    cacheWriteTimer = setTimeout(
+      () => writeCacheObject(cachePath, cache, true),
+      persistCacheAfter
+    );
+  }
+}
+
 async function getCache (cachePath, key) {
   const cache = await getCacheObject(cachePath);
   const value = cache[key];
@@ -728,16 +756,10 @@ async function getCache (cachePath, key) {
   return value;
 }
 
-let cacheWriteTimer = 0;
 async function setCache (cachePath, key, value) {
   const cache = await getCacheObject(cachePath)
   cache[key] = value;
-  clearTimeout(cacheWriteTimer);
-  cacheWriteTimer = setTimeout(() => {
-    fs.ensureDir(path.resolve(cachePath, '..'))
-      .then(() => fs.writeFile(cachePath, JSON.stringify(cache), {encoding: 'utf8'}))
-      .catch(error => console.error('Failed to write cache:', error));
-  }, 5000);
+  writeCacheObject(cachePath, cache);
 }
 
 function withCache (cachePath, name, operation, args, callback) {

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -608,7 +608,7 @@ function alphabeticalSort(a, b) {
   return a.localeCompare(b);
 }
 
-function getResponse (apiPath, qs) {
+function getResponse (apiPath, query) {
   const requestOptions = {};
   if (dbCredentials) {
     requestOptions.auth = dbCredentials;
@@ -616,8 +616,8 @@ function getResponse (apiPath, qs) {
 
   return new Promise((resolve, reject) => {
     let url = /^http(s?):\/\//.test(apiPath) ? apiPath : `${dbUrl}${apiPath}`;
-    if (qs) {
-      url += '?' + qs.stringify(qs, {
+    if (query) {
+      url += '?' + qs.stringify(query, {
         arrayFormat: 'brackets',
         sort: alphabeticalSort
       });

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -718,10 +718,10 @@ function withCache (cachePath, name, operation, args, callback) {
       const result = await promised(operation, ...args);
       await fs.ensureDir(cachePath);
       await fs.writeFile(filePath, JSON.stringify(result), {encoding: 'utf8'});
-      return response;
+      return result;
     })
     .then(
-      response => callback(null, response),
+      result => callback(null, result),
       error => callback(error)
     );
 }

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -623,7 +623,8 @@ function getResponse (apiPath, query) {
       });
     }
 
-    withCache(requestCache, url, getWithRetries, [url, requestOptions, 3], function (error, response) {
+    const cacheName = url.replace(/^http(s?):\/\/[^\/]\/?/, '');
+    withCache(requestCache, cacheName, getWithRetries, [url, requestOptions, 3], function (error, response) {
       if (args['--debug']) {
         console.log(`Got ${url}`);
       }

--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -144,6 +144,7 @@ Completed in ${result.queryDuration / 1000} seconds`,
   })
   .then(async results => {
     await clearCache(requestCache);
+    return results;
   })
   .then(sendResults)
   .catch(error => console.error(error.stack || error))
@@ -755,6 +756,7 @@ function withCache (cachePath, name, operation, args, callback) {
 
 async function clearCache (cachePath) {
   try {
+    clearTimeout(cacheWriteTimer);
     await fs.remove(cachePath);
   }
   catch (error) {


### PR DESCRIPTION
Last night I ran into persistent problems getting a full run of the analyst’s task sheets because the database kept dying in the middle. The real solution for that is edgi-govdata-archiving/web-monitoring-db#548, but in the mean time, as an emergency fix, I added a caching mechanism for all our API requests. That way, we can resume a broken job from halfway, and not put the same load right back on the database again.

The basic idea here is to wrap all the HTTP requests in `withCache`, which loads the cache and returns a cached result if present or, if not, runs the underlying function (the HTTP request) and caches the result. Every five seconds, it pesists the cache to disk.