### PR TITLE
Update selector for a site's last change time

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -165,8 +165,8 @@ class Versionista {
         return rows.map(row => {
           const link = row.querySelector('a.kwbase');
           // There's no longer any reliable class for "time since last change",
-          // but the cell has the ID `react_DashSiteChange{siteId}`
-          const updateElement = row.querySelector('[id*="DashSiteChange"] .h');
+          // but it is the next cell from "new pages found".
+          const updateElement = row.querySelector('.kwnewfound + td .h');
           let lastUpdateSecondsAgo = 0;
           if (updateElement) {
             lastUpdateSecondsAgo = parseFloat(updateElement.textContent);
@@ -175,7 +175,7 @@ class Versionista {
             // It appears that if there were no updates in the past year or so,
             // the `.h` element will be replaced with `.anev`. This is
             // imperfect, but basically just treat it as "1 year ago."
-            if (row.querySelector('[id*="DashSiteChange"] .anev')) {
+            if (row.querySelector('.kwnewfound + td .anev')) {
               lastUpdateSecondsAgo = 1000 * 60 * 60 * 24 * 365;
             }
             else {


### PR DESCRIPTION
There used to be a unique ID we could use to identify the cell holding the time since the last change on a site, but that appears to be gone. There's really no identifying ID, class, or other attribute anymore, so this now just uses the next cell after the "new pages found" cell.