### PR TITLE
Don't print total chunks in debug output

### DIFF
--- a/bin/query-db-and-email
+++ b/bin/query-db-and-email
@@ -795,7 +795,7 @@ function getAllResults (apiPath, qs) {
   return getResponse(apiPath, qs)
     .then(body => {
       if (args['--debug']) {
-        console.log(`Got ${getChunk(apiPath)} of ${getChunk(body.links.last)}`);
+        console.log(`Got ${getChunk(apiPath)}`);
       }
 
       // Concatenate the next page onto the end of this one if there is one.


### PR DESCRIPTION
We no longer have information about the last chunk or the total number of chunks, so we can't print this info. See this API change for more details: https://github.com/edgi-govdata-archiving/web-monitoring-db/pull/596

(On the upside, the API change will result in this script running much faster. 😄)