### PR TITLE
Test live site in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - dependency-cache-1-{{ checksum "package-lock.json" }}
+            - dependency-cache-1-{{ checksum "yarn.lock" }}
             - dependency-cache-1-
       - run:
           name: Dependencies
-          command: npm ci
+          command: yarn install --frozen-lockfile
       - save_cache:
-          key: dependency-cache-1-{{ checksum "package-lock.json" }}
+          key: dependency-cache-1-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             # - VERSIONISTA_NAME
             mkdir test-run
             bin/scrape-versionista \
-              --from 168 \
+              --after 168 \
               --output test-run/output.json \
               --save-content \
               --save-diffs \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,53 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.16
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - dependency-cache-1-{{ checksum "package-lock.json" }}
+            - dependency-cache-1-
+      - run:
+          name: Dependencies
+          command: npm ci
+      - save_cache:
+          key: dependency-cache-1-{{ checksum "package-lock.json" }}
+          paths:
+            - ./node_modules
+      - run:
+          name: Scrape Versionista
+          command: |
+            # NOTE: Account login info is provided by environment vars:
+            # - VERSIONISTA_EMAIL
+            # - VERSIONISTA_PASSWORD
+            # - VERSIONISTA_NAME
+            mkdir test-run
+            bin/scrape-versionista \
+              --from 168 \
+              --output test-run/output.json \
+              --save-content \
+              --save-diffs \
+              --parallel 2 \
+              --rate 30
+            # Print nicely formatted output for inspection
+            echo "-------------- OUTPUT DATA ------------------"
+            cat test-run/output.json | jq
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build
+
+  nightly:
+    jobs:
+      - build
+    triggers:
+      - schedule:
+          cron: '0 0 * * *'
+          filters:
+             branches:
+               only:
+                 - master


### PR DESCRIPTION
Since Versionista updates its UI every so often, it might help to run a scrape nightly and make sure there are no errors. That’s not perfect (there are plenty of silent errors when we scrape, too), but it’s a lot better than nothing!

I’ve made a new free account just for testing that only has a few pages, but which will update regularly, so this should always grab some data.