### PR TITLE
HOTFIX: the pages of a site now come from an API

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -201,16 +201,104 @@ class Versionista {
    * @returns {Promise<VersionistaPage[]>}
    */
   getPages (siteUrl) {
-    return this.request(siteUrl).then(window => {
-      const pagingUrls = getPagingUrls(window);
+    const site = parseVersionistaUrl(siteUrl);
 
-      let allPages = [getPageDetailData(window)];
-      allPages = allPages.concat(pagingUrls.slice(1).map(pageUrl => {
-        return this.request(pageUrl).then(getPageDetailData);
-      }));
+    // Versionista seems to be growing a bit of an API, but it may not be very
+    // stable yet. Observed schema has a `data` property and `page` object:
+    const apiSiteDataSchema = {
+      // Title of the page.
+      title_alt: 'string',
+      // Base URL for the site. May be needed to combine with a page's URL to
+      // form a complete URL for the page.
+      base: 'string',
+      // Unknown.
+      folder: 'number',
+      // Status. Not sure on possible values, see the page schema as a guide.
+      st: 'string',
+      // ID of the site.
+      id: 'string',
+      // Any additional notes.
+      notes: 'string'
+    };
+    const apiPageSchema = {
+      // Title of page. Only present if the page is not new and a title could
+      // be parsed from the content.
+      title: 'string?',
+      // Array of string flags. Not sure what all the possible values are. May
+      // be an empty array, but always present.
+      flags: 'array',
+      // URL of page. May be a complete URL or may just be a path that you must
+      // combine with the site's `base` property.
+      url: 'string',
+      // Date last checked as Unix timestamp (seconds since seconds since
+      // Jan 01 1970, UTC). Not present for "new" pages.
+      lchk: 'number?',
+      // Not sure what this is. We've never seen it absent and it's always 1.
+      beacon: 'number',
+      // Number of versions of the page. May be 0, but never absent.
+      vers: 'number',
+      // ID of the page.
+      id: 'string',
+      // Status of the page. Known possible values:
+      // - `A` (added and actively monitored)
+      // - `I` (paused but previously monitored)
+      // - `N` (newly detected but not actively monitored)
+      // Most of the optional values in this schema are present for A and I,
+      // but not for N.
+      st: 'string',
+      // Date added as a Unix timestamp.
+      added: 'number',
+      // Mime type. Always present, but may be an empty string.
+      mime: 'string',
+      // ID of latest version of the page.
+      cur_ver: 'number',
+      // Not sure what this is. If present, it's always 1.
+      seenlast: 'number?',
+      // Date of the latest version of the page as Unix timestamp.
+      lnew: 'number?'
+    };
 
-      return Promise.all(allPages).then(flatten);
+    const apiUrl = `https://versionista.com/api/site/${site.siteId}/`;
+    return this.request({url: apiUrl, json: true}).then(response => {
+      const apiData = response.body;
+      if (Array.isArray(apiData)) {
+        throw new Error(`Response from page listing API was not a JSON object: ${apiUrl}`);
+      }
+      if (!apiData.data || !apiData.pages) {
+        throw new Error(`Response from page listing API did not have 'data' and 'pages' properties: ${apiUrl}`);
+      }
+      if (Array.isArray(apiData.pages)) {
+        throw new Error(`The 'pages' property in the page listing API was not an object: ${apiUrl}`);
+      }
+
+      const siteBase = apiData.data.base;
+      // TODO: once we are reasonably confident in the schema, just assert on
+      // the first item for performance.
+      return Object.entries(apiData.pages).map(([id, apiPage]) => {
+        assertSchema(
+          apiPageSchema,
+          apiPage,
+          `Page does not match expected schema. ID: ${id}, URL: ${apiUrl}, $ERROR`);
+
+        let remoteUrl = apiPage.url;
+        if (!/^\w+:\/\//.test(remoteUrl)) {
+          remoteUrl = siteBase + remoteUrl;
+        }
+
+        return {
+          id: apiPage.id,
+          url: remoteUrl,
+          versionistaUrl: `https://versionista.com/${site.siteId}/${apiPage.id}/`,
+          title: apiPage.title,
+          lastChange: apiPage.lnew && new Date(apiPage.lnew * 1000),
+          lastChecked: apiPage.lchk && new Date(apiPage.lchk * 1000),
+          dateAdded: new Date(apiPage.added * 1000),
+          totalVersions: apiPage.vers
+        };
+      });
     });
+
+
   }
 
   /**
@@ -246,12 +334,11 @@ class Versionista {
       fst: 'number',
       content_type: 'string',
       lst: 'number',
-      id: undefined
+      id: undefined,
       // Only present if true
-      // stored: 'boolean'
-      // Only present if it has a value
-      // seen: 'number',
-      // title: 'string'
+      stored: 'boolean?',
+      seen: 'number?',
+      title: 'string?'
     };
     const versionsApiUrl = `https://versionista.com/api/versions/${page.siteId}/${page.pageId}`;
     return this.request({url: versionsApiUrl, json: true}).then(response => {
@@ -823,93 +910,6 @@ function getPagingUrls (window) {
     .map(link => link.href)
 };
 
-function getPageDetailData (window) {
-  const table = window.document.querySelector('table#siteView');
-  if (!table) {
-    throw new Error(`Could not find table of pages on site page listing ${window.location.href}`);
-  }
-
-  const xpathRows = xpath(window.document, "//div[contains(text(), 'URL')]/../../../following-sibling::tbody/tr");
-  return xpathRows.map(row => {
-    let lastChange = null;
-    const updateTimeText = xpathNode(row, "./td[8]").textContent.trim();
-    if (!/^(\d*(\.\d*)?|[\-–—])$/.test(updateTimeText)) {
-      throw new Error(oneLine(`Expected update time to be a numeric timestamp,
-        but got "${updateTimeText}" (${window.location.href})`));
-    }
-    else {
-      const timestamp = parseFloat(updateTimeText);
-      if (!Number.isNaN(timestamp)) {
-        lastChange = new Date(1000 * timestamp);
-        if (lastChange.getUTCFullYear() < 2000) {
-          throw new Error(oneLine(`Last change time for page does not seem
-            correct: "${lastChange}" from text "${updateTimeText}"
-            (${window.location.href})`));
-        }
-      }
-    }
-
-    const totalVersions = parseFloat(xpathNode(row, "./td[7]").textContent.trim());
-    const versionistaUrl = xpathNode(row, "./td[a][2]/a").href;
-
-    // Versionista's link to the live page used to be a redirect like:
-    //   https://versionista.com/viewUrl?{unencoded_destination_URL}
-    // It now appears just be a regular link. Try and handle both cases in case
-    // they switch it up again.
-    let remoteUrl = xpathNode(row, "./td[a][1]/a").href;
-    if (/^(\/|https?:\/\/[^\/]*versionista\.com)/i.test(remoteUrl)) {
-      const queryIndex = remoteUrl.indexOf('?');
-      if (queryIndex === -1) {
-        // Versionista no longer gives us a link to the original content if the
-        // last scan failed. Now we try and piece it together from the site URL
-        // at the top of the page and the path listed as text in this row.
-        const remotePathNode = xpathNode(row, "./td[4]/a");
-        if (!remotePathNode) {
-          throw new Error(`Cannot find this page's URL path in its site: "${remoteUrl}"`);
-        }
-        const remotePath = remotePathNode.textContent.trim();
-
-        // Sometimes it's actually a full URL, in which case we are good to go.
-        if (/^(http|https|ftp):/.test(remotePath)) {
-          remoteUrl = remotePath;
-        }
-        // But usually it's a path, so we have to go find the base URL.
-        else if (remotePath.startsWith('/')) {
-          // NOTE: I suspect this selector is pretty prone to failure.
-          const remoteBaseUrlNode = window.document.querySelector(
-            '#siteOptions a[title*="live site"]');
-          if (!remoteBaseUrlNode || !remoteBaseUrlNode.href.startsWith('http')) {
-            throw new Error(`Can't find base URL of web site to use with URL path: "${remotePath}" (Versionista: "${remoteUrl}")`);
-          }
-          const remoteBaseUrl = remoteBaseUrlNode.href.replace(/\/$/, '');
-          remoteUrl = remoteBaseUrl + remotePath;
-        }
-        // Otherwise, who knows!
-        else {
-          throw new Error(`The URL path for this page doesn't seem to be valid: "${remotePath}" (Versionista: ${remoteUrl})`);
-        }
-      }
-      remoteUrl = remoteUrl.slice(queryIndex + 1);
-    }
-
-    // Sanity-check totalVersions
-    if (!Number.isNaN(totalVersions) && totalVersions > 10000) {
-      throw new Error(oneLine(`A number was found for totalVersions, but it doesn’t
-        look like an actual version count! Versionista’s UI may have changed.
-        (${versionistaUrl})`));
-    }
-
-    return {
-      id: parseVersionistaUrl(versionistaUrl).pageId,
-      url: remoteUrl,
-      versionistaUrl: versionistaUrl,
-      title: xpathNode(row, "./td[a][3]").textContent.trim(),
-      lastChange,
-      totalVersions
-    };
-  });
-};
-
 function versionDataFromLink (versionLink) {
 
 }
@@ -920,15 +920,18 @@ function oneLine (string) {
 
 /**
  * Asserts that an object implements a given schema or throws an error if not.
- * The types are always strings, as returned by `typeof`. If the type is null
- * or undefined, then the presence of the property, but not its type will be
+ * The types are always strings (similar to those returned by `typeof`, but
+ * can differentiate 'object' and 'array'). If the type ends with '?', it will
+ * only be checked if the property is present. If the type is null or
+ * undefined, then the presence of the property, but not its type, will be
  * checked. The schema defines a minimum set of properties that the object must
  * support -- the object can have other properties not present in the schema.
  * @param {object} schema An object mapping keys to types, e.g.
  *        `{name: 'string', age: 'number'}`
  * @param {any} object Object that is expected to implement the schema
  * @param {string} [message] Optional message for the error that will be thrown
- *        if the schema does not match.
+ *        if the schema does not match. If the message has the text '$ERROR',
+ *        '$ERROR' will be replaced with detailed information.
  */
 function assertSchema(schema, object, message = null) {
   const keys = [
@@ -937,13 +940,38 @@ function assertSchema(schema, object, message = null) {
   ];
 
   keys.forEach(key => {
-    if (!(key in object)) {
-      throw new Error(message || `Object is missing property '${key}'`);
+    let type = schema[key];
+    let optional = false;
+    if ((typeof type === 'string') && type.endsWith('?')) {
+      optional = true;
+      type = type.slice(0, -1);
     }
-    if (schema[key] && !(typeof object[key] === schema[key])) {
-      throw new Error(message || `The '${key}' property of object was not a ${schema[key]}`);
+
+    if (!(key in object)) {
+      if (optional) return;
+
+      const error = `Object is missing property '${key}'`;
+      throw new Error(message ? message.replace('$ERROR', error) : error);
+    }
+
+    if (type && !isType(object[key], type)) {
+      const error = `The '${key}' property of object was not a ${type}`;
+      throw new Error(message ? message.replace('$ERROR', error) : error);
     }
   });
+}
+
+/**
+ * Check whether a value is of a given type. This can handle more types than
+ * 'typeof' can (it differentiates 'array' and 'object', for example).
+ * @param {any} value Value to check type of.
+ * @param {string} type Name of type to check that value is.
+ * @returns {boolean}
+ */
+function isType(value, type) {
+  if (type === 'array') return Array.isArray(value);
+  else if (type === 'object' && Array.isArray(value)) return false;
+  return typeof value === type;
 }
 
 module.exports = Versionista;


### PR DESCRIPTION
Ever since the data in the page details view got replaced by an API (#196), we've been waiting for the same to happen to the site details view. Now it has! This logic mostly mirrors the API logic we wrote for the page details view.

I’ve also expanded the type checking a bit to:
- Handle optional properties (we just didn't check their types before).
- Handle arrays (we don't check what types they are arrays *of*, though).

Also: yay for CI alerting us early to this failure! :D (see #238)
https://circleci.com/gh/edgi-govdata-archiving/web-monitoring-versionista-scraper/33