### PR TITLE
Switch from Raven to newer Sentry SDK

### DIFF
--- a/lib/sentry-errors.js
+++ b/lib/sentry-errors.js
@@ -6,7 +6,7 @@
  */
 
 const EventEmitter = require('events');
-const Raven = require('raven');
+const Sentry = require('@sentry/node');
 
 const defaultOptions = {captureUnhandledRejections: true};
 const maximumWaitTime = 5000;
@@ -46,14 +46,15 @@ const asyncTracker = Object.assign(new EventEmitter(), {
   }
 });
 
-exports.setup = function (options, dsn = process.env['SENTRY_DSN']) {
+exports.setup = function (options, dsn = 'https://ded77ba6693a42fea73a23abd7c8de8f@sentry.io/1775138') {
   if (dsn) {
-    Raven.config(dsn, Object.assign({}, defaultOptions, options)).install();
+    const dsnObj = { dsn: dsn}
+    Sentry.init(Object.assign({}, dsnObj, defaultOptions, options))
   }
   return exports;
 }
 
-exports.captureException = asyncTracker.trackMethod(Raven, 'captureException');
-exports.captureMessage = asyncTracker.trackMethod(Raven, 'captureMessage');
+exports.captureException = asyncTracker.trackMethod(Sentry, 'captureException');
+exports.captureMessage = asyncTracker.trackMethod(Sentry, 'captureMessage');
 exports.flush = () => asyncTracker.waitUntilInactive();
-exports.Raven = Raven;
+exports.Sentry = Sentry;

--- a/lib/sentry-errors.js
+++ b/lib/sentry-errors.js
@@ -5,46 +5,10 @@
  * wait until calls to Sentry.io are complete.
  */
 
-const EventEmitter = require('events');
 const Sentry = require('@sentry/node');
 
 const defaultOptions = {captureUnhandledRejections: true};
 const maximumWaitTime = 5000;
-
-const asyncTracker = Object.assign(new EventEmitter(), {
-  active: 0,
-
-  trackMethod (context, functionName) {
-    return (...args) => {
-      return new Promise(resolve => {
-        this.active++;
-        context[functionName](...args, () => {
-          this.active--;
-          if (this.active === 0) {
-            this.emit('allMessagesEnded');
-          }
-          resolve();
-        });
-      });
-    };
-  },
-
-  waitUntilInactive () {
-    return new Promise(resolve => {
-      if (this.active === 0) {
-        return resolve();
-      }
-
-      const timer = setTimeout(listener, maximumWaitTime);
-      this.on('allMessagesEnded', listener);
-      function listener () {
-        this.removeListener('allMessagesEnded', listener);
-        clearTimeout(timer);
-        resolve();
-      }
-    });
-  }
-});
 
 exports.setup = function (options) {
   Sentry.init(Object.assign({}, defaultOptions, options))

--- a/lib/sentry-errors.js
+++ b/lib/sentry-errors.js
@@ -46,11 +46,8 @@ const asyncTracker = Object.assign(new EventEmitter(), {
   }
 });
 
-exports.setup = function (options, dsn = 'https://ded77ba6693a42fea73a23abd7c8de8f@sentry.io/1775138') {
-  if (dsn) {
-    const dsnObj = { dsn: dsn}
-    Sentry.init(Object.assign({}, dsnObj, defaultOptions, options))
-  }
+exports.setup = function (options) {
+  Sentry.init(Object.assign({}, defaultOptions, options))
   return exports;
 }
 

--- a/lib/sentry-errors.js
+++ b/lib/sentry-errors.js
@@ -7,11 +7,12 @@
 
 const Sentry = require('@sentry/node');
 
-const defaultOptions = {captureUnhandledRejections: true};
 const maximumWaitTime = 5000;
 
+// For options information, see:
+// https://docs.sentry.io/error-reporting/configuration/?platform=node
 exports.setup = function (options) {
-  Sentry.init(Object.assign({}, defaultOptions, options))
+  Sentry.init(options);
   return exports;
 }
 

--- a/lib/sentry-errors.js
+++ b/lib/sentry-errors.js
@@ -51,7 +51,7 @@ exports.setup = function (options) {
   return exports;
 }
 
-exports.captureException = asyncTracker.trackMethod(Sentry, 'captureException');
-exports.captureMessage = asyncTracker.trackMethod(Sentry, 'captureMessage');
-exports.flush = () => asyncTracker.waitUntilInactive();
+exports.captureException = Sentry.captureException;
+exports.captureMessage = Sentry.captureMessage;
+exports.flush = (timeout = maximumWaitTime) => Sentry.flush(timeout);
 exports.Sentry = Sentry;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^3.3.1",
-    "@sentry/node": "^5.6.2",
+    "@sentry/node": "5.7.0",
     "aws-sdk": "^2.541.0",
     "csv-parse": "^4.4.7",
     "fs-promise": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@google-cloud/storage": "^3.3.1",
+    "@sentry/node": "^5.6.2",
     "aws-sdk": "^2.541.0",
     "csv-parse": "^4.4.7",
     "fs-promise": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,62 @@
     through2 "^3.0.0"
     xdg-basedir "^4.0.0"
 
+"@sentry/core@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.7.0.tgz#c2aa5341e703ec7cf2acc69e51971a0b1f7d102a"
+  integrity sha512-gQel0d7LBSWJGHc7gfZllYAu+RRGD9GcYGmkRfemurmDyDGQDf/sfjiBi8f9QxUc2iFTHnvIR5nMTyf0U3yl3Q==
+  dependencies:
+    "@sentry/hub" "5.7.0"
+    "@sentry/minimal" "5.7.0"
+    "@sentry/types" "5.7.0"
+    "@sentry/utils" "5.7.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.7.0.tgz#f7c356202a9db1daae82ce7f48ebf1139e4e9d02"
+  integrity sha512-qNdYheJ6j4P9Sk0eqIINpJohImmu/+trCwFb4F8BGLQth5iGMVQD6D0YUrgjf4ZaQwfhw9tv4W6VEfF5tyASoA==
+  dependencies:
+    "@sentry/types" "5.7.0"
+    "@sentry/utils" "5.7.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.7.0.tgz#832d26bcd862c6ea628d48ad199ac7f966a2d907"
+  integrity sha512-0sizE2prS9nmfLyVUKmVzFFFqRNr9iorSCCejwnlRe3crqKqjf84tuRSzm6NkZjIyYj9djuuo9l9XN12NLQ/4A==
+  dependencies:
+    "@sentry/hub" "5.7.0"
+    "@sentry/types" "5.7.0"
+    tslib "^1.9.3"
+
+"@sentry/node@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.7.0.tgz#153777f06b2fcd346edbff9adbb6b231c7e5fa0a"
+  integrity sha512-iqQbGAJDBlpQkp1rl9RkDCIfnukr4cOtHPgJPmLY19m/KXIHD2cdKhvbqoCvIPBTIAeSGQIvDT9jD5zT46eoqQ==
+  dependencies:
+    "@sentry/core" "5.7.0"
+    "@sentry/hub" "5.7.0"
+    "@sentry/types" "5.7.0"
+    "@sentry/utils" "5.7.0"
+    cookie "^0.3.1"
+    https-proxy-agent "^3.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.7.0.tgz#e8677e57b40c2c63cad42c02add12b238e647c10"
+  integrity sha512-bFRVortg713dE2yJXNFgNe6sNBVVSkpoELLkGPatdVQi0dYc6OggIIX4UZZvkynFx72GwYqO1NOrtUcJY2gmMg==
+
+"@sentry/utils@5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.7.0.tgz#a6850aa4f5476fa26517cd5c6248f871d8d9939b"
+  integrity sha512-XmwQpLqea9mj8x1N7P/l4JvnEb0Rn5Py5OtBgl0ctk090W+GB1uM8rl9mkMf6698o1s1Z8T/tI/QY0yFA5uZXg==
+  dependencies:
+    "@sentry/types" "5.7.0"
+    tslib "^1.9.3"
+
 abab@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
@@ -91,7 +147,7 @@ acorn@^6.0.1, acorn@^6.1.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
   integrity sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==
 
-agent-base@4:
+agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
   integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
@@ -278,7 +334,7 @@ configstore@^5.0.0:
     write-file-atomic "^3.0.0"
     xdg-basedir "^4.0.0"
 
-cookie@0.3.1:
+cookie@0.3.1, cookie@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
@@ -624,6 +680,14 @@ https-proxy-agent@^2.2.1:
     agent-base "^4.1.0"
     debug "^3.1.0"
 
+https-proxy-agent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-3.0.0.tgz#0106efa5d63d6d6f3ab87c999fa4877a3fd1ff97"
+  integrity sha512-y4jAxNEihqvBI5F3SaO2rtsjIOnnNA8sEbuiP+UhJZJHeM2NRm6c09ax2tgqme+SgUUvjao2fJXF4h3D6Cb2HQ==
+  dependencies:
+    agent-base "^4.3.0"
+    debug "^3.1.0"
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -786,6 +850,11 @@ lru-cache@^5.0.0:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 make-dir@^3.0.0:
   version "3.0.0"
@@ -1249,6 +1318,11 @@ tr46@^1.0.1:
 "traverse@>=0.3.0 <0.4":
   version "0.3.9"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.3.9.tgz#717b8f220cc0bb7b44e40514c22b2e8bbc70d8b9"
+
+tslib@^1.9.3:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Hi, sorry for the wait. Here's the PR for issue 162.

I did an npm install for Sentry, let me know if you want a yarn instead. Otherwise, I changed all instances where Raven was used to Sentry. Lastly, as requested changed the signature for exports.setup to only use options. 

Please let me know if there are any issues!