### PR TITLE
Use `captureMessages` when logging string errors

### DIFF
--- a/bin/scrape-versionista
+++ b/bin/scrape-versionista
@@ -151,7 +151,14 @@ function logError (error) {
 
   errorStream.write(error.stack || error.message || error.toString());
   errorStream.write('\n');
-  sentryErrors.captureException(error);
+
+  // Also send it along to the error tracking service.
+  if (typeof error == 'string') {
+    sentryErrors.captureMessage(error);
+  }
+  else {
+    sentryErrors.captureException(error);
+  }
 }
 
 function flushErrors () {


### PR DESCRIPTION
Unlike the old Raven SDK, the new Sentry SDK doesn't appear to handle strings passed to `captureException` as well (they don't break, but you don't get very clear messaging in Sentry). Instead, check whether we are logging an error or a string and choose `captureException()` or `captureMessage()` as appropriate.

Generating a sample error that is a string using `captureException()`:

![Screen Shot 2019-10-14 at 10 47 17 AM](https://user-images.githubusercontent.com/74178/66771810-16eeb000-ee70-11e9-8171-81b90ab19625.png)

And using `captureMessage()` in this case instead:

![Screen Shot 2019-10-14 at 10 47 23 AM](https://user-images.githubusercontent.com/74178/66771828-21a94500-ee70-11e9-910b-602c2539233d.png)

This is a follow-on to #245.