### PR TITLE
Allow IDs to be numbers in Versionista's API

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -235,7 +235,7 @@ class Versionista {
       // Number of versions of the page. May be 0, but never absent.
       vers: 'number',
       // ID of the page.
-      id: 'string',
+      id: 'string|number',
       // Status of the page. Known possible values:
       // - `A` (added and actively monitored)
       // - `I` (paused but previously monitored)
@@ -276,6 +276,9 @@ class Versionista {
           apiPageSchema,
           apiPage,
           `Page does not match expected schema. ID: ${id}, URL: ${apiUrl}, $ERROR`);
+
+        // Ensure IDs are strings (they may be numbers)
+        apiPage.id = apiPage.id.toString(10);
 
         let remoteUrl = apiPage.url;
         if (!/^\w+:\/\//.test(remoteUrl)) {
@@ -824,9 +827,12 @@ function assertSchema(schema, object, message = null) {
   keys.forEach(key => {
     let type = schema[key];
     let optional = false;
-    if ((typeof type === 'string') && type.endsWith('?')) {
-      optional = true;
-      type = type.slice(0, -1);
+    if ((typeof type === 'string')) {
+      if (type.endsWith('?')) {
+        optional = true;
+        type = type.slice(0, -1);
+      }
+      type = type.split('|').map(item => item.trim()).filter(item => !!item);
     }
 
     if (!(key in object)) {
@@ -851,7 +857,8 @@ function assertSchema(schema, object, message = null) {
  * @returns {boolean}
  */
 function isType(value, type) {
-  if (type === 'array') return Array.isArray(value);
+  if (Array.isArray(type)) return type.some(item => isType(value, item));
+  else if (type === 'array') return Array.isArray(value);
   else if (type === 'object' && Array.isArray(value)) return false;
   return typeof value === type;
 }


### PR DESCRIPTION
Page IDs appear to have changed from strings to numbers today, so we should accept either, but coerce numeric IDs to strings for sanity's sake.