### PR TITLE
HOTFIX: class names on the 'sites' listing changed

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -162,8 +162,11 @@ class Versionista {
         return rows.map(row => {
           const link = row.querySelector('a.kwbase');
           // There's no longer any reliable class for "time since last change",
-          // but it is the next cell from "new pages found".
-          const updateElement = row.querySelector('.kwnewfound + td .h');
+          // but it is the last cell.
+          const updateElement = Array.from(row.childNodes)
+            .filter(node => node.nodeName === 'TD')
+            .pop()
+            .querySelector('.h');
           let lastUpdateSecondsAgo = 0;
           if (updateElement) {
             lastUpdateSecondsAgo = parseFloat(updateElement.textContent);


### PR DESCRIPTION
The classes we used to use to identify the "since" column on the list of sites changed, and there's pretty much no useful classes or attributes left there, so this required some slightly more complex code to find the right element.

See this failed nightly run for an example: https://app.circleci.com/pipelines/github/edgi-govdata-archiving/web-monitoring-versionista-scraper/779/workflows/6deae247-2d2e-49e9-95fb-1fe8cb3197e4/jobs/955