### PR TITLE
Disable nightly builds on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,4 +50,4 @@ workflows:
           filters:
              branches:
                only:
-                 - master
+                 - main


### PR DESCRIPTION
It turns out that, because we didn't update the CircleCI config on `master` when we switched to `main` as our default branch, Circle has been running nightly tests on both `main` and `master`! Not good.