### PR TITLE
HOTFIX: Use CSV for sites list instead of scraping

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -149,49 +149,35 @@ class Versionista {
    * @returns {Promise<VersionistaSite[]>}
    */
   getSites () {
-    return this.request('https://versionista.com/home?show_all=1')
-      .then(window => {
-        const table = window.document.querySelector('.sorttable');
-        if (!table) {
-          throw new Error(`HTML for site listing has no table of sites`);
+    // Parse site data out of the CSV that lists all pages.
+    return this.request({
+      url: 'https://versionista.com/download/urls.csv',
+      parseBody: false
+    })
+      .then(response => parsePagesCsv(response.body))
+      .then(csv => {
+        const sites = new Map();
+        for (const page of csv) {
+          if (!page.last_version) continue;
+
+          const urlInfo = parseVersionistaUrl(page.last_version);
+          let site = sites.get(urlInfo.siteId);
+          if (!site) {
+            site = {
+              id: urlInfo.siteId,
+              name: page.parent_site,
+              url: `https://versionista.com/${urlInfo.siteId}/`,
+              lastChange: page.last_new
+            };
+            sites.set(urlInfo.siteId, site);
+          }
+
+          if (site.lastChange < page.lastChange) {
+            site.lastChange = page.lastChange;
+          }
         }
 
-        const rows = Array.from(
-          window.document.querySelectorAll('.sorttable > tbody > tr'));
-
-        return rows.map(row => {
-          const link = row.querySelector('a.kwbase');
-          // There's no longer any reliable class for "time since last change",
-          // but it is the last cell.
-          const updateElement = Array.from(row.childNodes)
-            .filter(node => node.nodeName === 'TD')
-            .pop()
-            .querySelector('.h');
-          let lastUpdateSecondsAgo = 0;
-          if (updateElement) {
-            lastUpdateSecondsAgo = parseFloat(updateElement.textContent);
-          }
-          else {
-            // It appears that if there were no updates in the past year or so,
-            // the `.h` element will be replaced with `.anev`. This is
-            // imperfect, but basically just treat it as "1 year ago."
-            if (row.querySelector('.kwnewfound + td .anev')) {
-              lastUpdateSecondsAgo = 1000 * 60 * 60 * 24 * 365;
-            }
-            else {
-              throw new Error('Could not find "since" field on the sites page.');
-            }
-          }
-
-          return {
-            id: parseVersionistaUrl(link.href).siteId,
-            name: link.textContent.trim(),
-            url: link.href,
-            lastChange: (Number.isNaN(lastUpdateSecondsAgo))
-              ? null
-              : new Date(window.requestDate - lastUpdateSecondsAgo * 1000)
-          };
-        });
+        return Array.from(sites.values());
       });
   }
 
@@ -201,6 +187,9 @@ class Versionista {
    * @returns {Promise<VersionistaPage[]>}
    */
   getPages (siteUrl) {
+    // TODO: Now that getSites() uses a CSV of all pages instead of scraping,
+    // consider using its output here for getPages as well. (Then we could get
+    // all pages for all sites much more quickly.)
     const site = parseVersionistaUrl(siteUrl);
 
     // Versionista seems to be growing a bit of an API, but it may not be very
@@ -778,6 +767,63 @@ function parseVersionistaUrl (url) {
     pageId: ids[1],
     versionId: ids[2] && ids[2].split(':')[0]
   };
+}
+
+/**
+ * @typedef {Object} CsvPageRecord
+ * @property {String} page_url
+ * @property {String} page_status Should be `"monitored" | "newfound" | "paused"`
+ * @property {Number} versions
+ * @property {Date} added
+ * @property {Date} last_new
+ * @property {String} response_code
+ * @property {Date} last_checked
+ * @property {String} title
+ * @property {String} last_version URL to the most recent version
+ * @property {String} last_change URL to the most recent change comparison
+ */
+
+/**
+ * Parse a CSV that lists high level info about the pages in a site or account.
+ * @param {string} csvString The CSV to parse
+ * @returns {Promise<CsvPageRecord[]>}
+ */
+function parsePagesCsv(csvString) {
+  return csvParsePromise(csvString.toString(), {
+    cast: true,
+    cast_date: true,
+    columns (names) {
+      // lower-case, replace spaces with `_`, remove parentheticals:
+      // 'Load time' -> 'load_time'
+      const result = names.map(name =>
+        name.toLowerCase().replace(/\s+\(.+?\)/g, '').replace(/\s/g, '_'));
+
+      // Validate
+      const columns = [
+        'page_url',
+        'page_status',   // "monitored" | "newfound" | "paused"
+        'versions',      // Count
+        'added',         // Date
+        'last_new',      // Date | "none"
+        'response_code', // Includes text message, e.g. "200 OK"
+        'last_checked',  // Date | "never"
+        'title',
+        'last_version',  // URL, e.g. "https://versionista.com/143338/11052600/32961879/"
+        'last_change'    // URL, e.g. "https://versionista.com/143338/11052600/32961879:0/"
+      ];
+      columns.forEach(name => {
+        if (!result.includes(name)) throw new Error(`Page CSV is missing required columns: ${columns.join(', ')}`);
+      });
+
+      return result;
+    },
+    on_record (record, _context) {
+      if (record.last_new === "none") record.last_new = null;
+      if (record.last_checked === "never") record.last_checked = null;
+
+      return record;
+    }
+  });
 }
 
 function hash (text) {


### PR DESCRIPTION
We used to scrape the content of the main page that listed all the sites to get a list of sites. That page is now empty and populated entirely by JS, so we now get this information by downloading a CSV of all URLs in the account and boiling down a list of sites from that.