### PR TITLE
Update diff and version downloads

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -569,17 +569,18 @@ class Versionista {
    * TODO: should return an object indicating type (so we can do correct file
    * extensions for PDF, mp4, etc.)
    * @param {String} versionUrl
-   * @param {Number} retries Number of times to retry if there's a cache timeout
    * @returns {Promise<String|Buffer>}
    */
-  getVersionRawContent (versionUrl, retries = 2) {
-    // This is similar to getVersionDiffHtml, but we get to skip a step (yay!)
-    // The "api" for this is available directly at versionista.com.
-    const apiUrl = versionUrl.replace(
-      /(versionista.com\/)(.*)$/,
-      '$1api/ip_url/$2/raw');
+  getVersionRawContent (versionUrl) {
+    if (!versionUrl.endsWith('/')) versionUrl += '/';
+    const rawUrl = versionUrl + 'download';
 
-    return this.request({url: apiUrl, parseBody: false})
+    return this.request({
+      url: rawUrl,
+      // A version may be binary data (for PDFs, videos, etc.)
+      encoding: null,
+      parseBody: false
+    })
       .then(response => {
         if (response.statusCode >= 400) {
           const error = new Error(`Invalid version URL: '${versionUrl}'`);
@@ -587,75 +588,19 @@ class Versionista {
           throw error;
         }
 
-        let rawUrl = response.body;
-        if (!/^https?:\/\//.test(rawUrl)) {
-          rawUrl = `https://versionista.com${rawUrl}`;
+        if (!Buffer.isBuffer(response.body)) {
+          throw new Error(`Unexpected response: '${versionUrl}'`);
         }
 
-        return this.request({
-          url: rawUrl,
-          // The URL from the API is time limited, so prioritize the request
-          immediate: true,
-          // A version may be binary data (for PDFs, videos, etc.)
-          encoding: null,
-          parseBody: false,
-          stringifyHtml: true
-        });
-      })
-      // The raw source is the text of the `<pre>` element. A different type of
-      // result (called "safe" in versionista's API) gets us an actual webpage,
-      // but it appears that the source there has been parsed, cleaned up
-      // (made valid HTML), and had Versionista analytics inserted.
-      .then(response => {
         let mimeExtension = mime.extension(response.headers['content-type']);
-        const buildResult = (extras) => {
-          const result = Object.assign({
-            headers: response.headers,
-            body: response.body,
-            extension: mimeExtension ? `.${mimeExtension}` : ''
-          }, extras);
-          result.hash = hash(result.body);
-          result.length = Buffer.byteLength(result.body, 'utf8');
-          return result;
+        const result = {
+          headers: response.headers,
+          body: response.body,
+          extension: mimeExtension ? `.${mimeExtension}` : '',
+          hash: hash(response.body),
+          length: Buffer.byteLength(response.body, 'utf8')
         };
-
-        // Sometimes a version may have no content (e.g. a page was removed).
-        // This is OK.
-        if (response.body.toString() === '') {
-          return buildResult({body: ''});
-        }
-        // Are we dealing with HTML?
-        else if (typeof response.body === 'string') {
-          let source = response.body;
-
-          if (/^<h\d>Cache expired<\/h\d>/i.test(source)) {
-            // fall through to the error if there are no more retries
-            if (retries) {
-              return this.getVersionRawContent(versionUrl, retries - 1);
-            }
-          }
-          else {
-            // For some reason Versionista seems to insert some blank lines
-            if (source.startsWith('\n\n\n')) {
-              source = source.slice(3);
-            }
-            // Clear out Versionista additions (even though there's nothing
-            // actually between these comments in `raw` responses).
-            source = source.replace(versionistaSourceAdditionsPattern, '');
-
-            return buildResult({body: source});
-          }
-        }
-        else if (Buffer.isBuffer(response.body)) {
-          return buildResult({body: response.body});
-        }
-
-        // FAILURE!
-        const error = new Error(`Can't find raw content for ${versionUrl}`);
-        error.code = 'VERSIONISTA:NO_VERSION_CONTENT';
-        error.urls = [versionUrl, apiUrl, response.request.uri.href];
-        error.receivedContent = response.body;
-        throw error;
+        return result;
       });
   }
 

--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -699,6 +699,7 @@ class Versionista {
         return `${diffHost}/api/ip_url${actualUri.pathname}${diffType}${actualUri.search || ''}`;
       })
       .then(apiUrl => this.request({
+        method: 'POST',
         url: apiUrl,
         parseBody: false,
         immediate: true


### PR DESCRIPTION
The Versionista endpoints for diffs and for getting raw version content both changed yesterday, breaking that functionality in this library.

- Diff endpoints now use POST instead of GET requests.
- The "API" we used to used for downloading raw(-ish) version content has been removed. Fortunately, there now a much simpler endpoint for downloading raw version content at `https://versionista.com/{site}/{page}/{version}/download`.