### PR TITLE
Update to newer `cimg/node` CircleCI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,18 +2,18 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/node:12.22
+      - image: cimg/node:12.22
     steps:
       - checkout
       - restore_cache:
           keys:
-            - dependency-cache-1-{{ checksum "yarn.lock" }}
-            - dependency-cache-1-
+            - dependency-cache-2-{{ checksum "yarn.lock" }}
+            - dependency-cache-2-
       - run:
           name: Dependencies
           command: yarn install --frozen-lockfile
       - save_cache:
-          key: dependency-cache-1-{{ checksum "yarn.lock" }}
+          key: dependency-cache-2-{{ checksum "yarn.lock" }}
           paths:
             - ./node_modules
       - run:


### PR DESCRIPTION
The old `circleci/*` images have now been officially deprecated; we should have updated this long ago.