### PR TITLE
Remove Raven, declare minimum Node.js version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/*
 tmp/*
 scratch.*
 .vscode
+.node-version
 
 # Google cloud keys
 *-key.json

--- a/lib/sentry-errors.js
+++ b/lib/sentry-errors.js
@@ -1,8 +1,8 @@
 'use strict';
 
 /**
- * A simplified interface to Sentry.io's Raven library that makes it easy to
- * wait until calls to Sentry.io are complete.
+ * A simplified interface to Sentry that makes it easy to wait until all calls
+ * to report errors are complete.
  */
 
 const Sentry = require('@sentry/node');

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
     "nodemailer": "^6.7.7",
     "parallel-transform": "^1.2.0",
     "pump": "^3.0.0",
-    "raven": "^2.6.4",
     "request": "^2.88.0",
     "split": "^1.0.1"
+  },
+  "engines": {
+    "node": ">=14.14.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,10 +236,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
 
-charenc@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz"
-
 combined-stream@1.0.6, combined-stream@~1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz"
@@ -258,10 +254,6 @@ compressible@^2.0.12:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
-cookie@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
-
 cookie@^0.4.1:
   version "0.4.1"
   resolved "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz"
@@ -269,10 +261,6 @@ cookie@^0.4.1:
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-
-crypt@~0.0.1:
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz"
 
 cssom@^0.5.0:
   version "0.5.0"
@@ -725,10 +713,6 @@ is-boolean-object@^1.1.0:
     call-bind "^1.0.2"
     has-tostringtag "^1.0.0"
 
-is-buffer@~1.1.1:
-  version "1.1.6"
-  resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
-
 is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.4.tgz#47301d58dd0259407865547853df6d61fe471945"
@@ -933,14 +917,6 @@ lru_map@^0.3.3:
   version "0.3.3"
   resolved "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz"
 
-md5@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz"
-  dependencies:
-    charenc "~0.0.1"
-    crypt "~0.0.1"
-    is-buffer "~1.1.1"
-
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -1096,16 +1072,6 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
 
-raven@^2.6.4:
-  version "2.6.4"
-  resolved "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz"
-  dependencies:
-    cookie "0.3.1"
-    md5 "^2.2.1"
-    stack-trace "0.0.10"
-    timed-out "4.0.1"
-    uuid "3.3.2"
-
 readable-stream@^2.1.5:
   version "2.3.6"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
@@ -1232,10 +1198,6 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-stack-trace@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
-
 stream-events@^1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz"
@@ -1292,10 +1254,6 @@ teeny-request@^8.0.0:
 through@2:
   version "2.3.8"
   resolved "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-
-timed-out@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz"
 
 tough-cookie@^4.0.0:
   version "4.0.0"
@@ -1384,10 +1342,6 @@ util@^0.12.4:
     is-typed-array "^1.1.3"
     safe-buffer "^5.1.2"
     which-typed-array "^1.1.2"
-
-uuid@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
 
 uuid@8.0.0:
   version "8.0.0"


### PR DESCRIPTION
We had Raven installed, but we didn't use it! (Raven was replaced by `@sentry/node`.) This clears it out, and also declares the minimum node.js version required, which for some reason we didn't do before.