### PR TITLE
Prevent parallel runs of integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
   scrape:
     name: Scrape Test Account
     runs-on: ubuntu-latest
+    # Prevent multiple jobs talking to Versionista at the same time; they'll
+    # fail to log in.
+    concurrency: versionista_integration
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Dealing with dependency updates is a pain, since there are multiple PRs triggering jobs at the same time. They often fail because Versionista doesn’t let them log in. Hopefully, preventing parallel runs will help.