### PR TITLE
Use new Login URL and response format

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -128,16 +128,25 @@ class Versionista {
   logIn (email, password) {
     if (!this._loggedIn) {
       this._loggedIn = this.request({
-        url: 'https://versionista.com/login',
+        url: 'https://versionista.com/api/login',
         method: 'POST',
         form: {em: email, pw: password},
-        followRedirect: false
+        followRedirect: false,
+        parseBody: false,
+        headers: {
+          Accept: 'application/json'
+        }
       })
-        .then(window => {
-          if (window.httpResponse.body.match(/log in/i)) {
-            const infoNode = window.document.querySelector('.alert');
-            const details = infoNode ? ` (${infoNode.textContent.trim()})` : '';
-            throw new Error(`Could not log in${details}`);
+        .then(response => {
+          let data;
+          try {
+            data = JSON.parse(response.body);
+          }
+          catch (error) {
+            throw new Error(`Could not parse JSON response for login: ${response.body}`);
+          }
+          if (data.success !== 'accepted') {
+            throw new Error(`Login did not succeed: ${response.body}`);
           }
         });
     }


### PR DESCRIPTION
Versionista now logs in using an API request that returns cookies and a confirmation in JSON format, rather than a login redirect that takes you to your account's home page. This uses the new approach, and fixes #491.