### PR TITLE
Stop Dependabot updates for this project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-    time: "10:00"
-  open-pull-requests-limit: 10


### PR DESCRIPTION
This project has effectively been in pure maintenance mode for a while, with no known active users. It no longer makes sense to keep accepting and merging regular dependency updates, so this turns off Dependabot version updates (we still have Dependabot *security* updates).

See also https://github.com/edgi-govdata-archiving/web-monitoring/issues/168.