### PR TITLE
Add retry for login

### DIFF
--- a/lib/versionista.js
+++ b/lib/versionista.js
@@ -135,7 +135,8 @@ class Versionista {
         parseBody: false,
         headers: {
           Accept: 'application/json'
-        }
+        },
+        retryIf: (response) => response.statusCode >= 500
       })
         .then(response => {
           let data;


### PR DESCRIPTION
Every few days the automated integration test fails with a 500 error when logging in. We don't normally retry on 500 errors (I wish I could remember why I made that decision), but I think it certainly makes sense to in this case.